### PR TITLE
Add deployment script for jenkins automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ This project is managed by the vanilla Clojure CLI tools, make sure
  brew tap clojure/tools
  brew install clojure/tools/clojure
  ```
- 
+
 You could then run `clj -m $namespace` to run a module with given namespace. e.g.
 
 ```bash
-clojure -m start
+clojure -m ptc.start
 ```
 
-The tests are managed by `clj` as well and will be executed by 
- [`kaocha`](https://github.com/lambdaisland/kaocha) test runner. You could 
+The tests are managed by `clj` as well and will be executed by
+ [`kaocha`](https://github.com/lambdaisland/kaocha) test runner. You could
  run the following code to see an example:
 
  ```bash
@@ -36,7 +36,7 @@ network and run:
  clojure -A:test integration
 ```
 
-which will run the end to end test including uploading some files to the 
+which will run the end to end test including uploading some files to the
 testing Google Cloud Storage Bucket.
 
 ## Development
@@ -52,13 +52,13 @@ $ tree .
 └── test
     └── start_test.clj
 ```
-The project structure is shown as above, you add new entries to `deps.edn` 
-to introduce a new dependency, add new modules to `src/` and implement new 
+The project structure is shown as above, you add new entries to `deps.edn`
+to introduce a new dependency, add new modules to `src/` and implement new
 test cases to `test/`.
 
 ### Code Style
 
-We use [`cljfmt`](https://github.com/weavejester/cljfmt) for a 
+We use [`cljfmt`](https://github.com/weavejester/cljfmt) for a
 standard and consistent code style in this repo.
 
 To lint the code, run:
@@ -78,11 +78,11 @@ simply run:
 
 ```bash
 bash ops/build.sh
-``` 
+```
 
 which should output the detailed information about what are thrown into the
 Jar file while building the executable Jar file to `target/push-to-cloud-service.jar`.
 
 You could run it with `java -jar target/push-to-cloud-service.jar`, which will invoke
-the main function in the `start.clj` namespace, which is currently the only module with 
+the main function in the `start.clj` namespace, which is currently the only module with
 `:gen-class`.

--- a/ops/build.sh
+++ b/ops/build.sh
@@ -4,7 +4,7 @@
 # information, see https://github.com/tonsky/uberdeps
 
 if [ ${USE_CPCACHE-1} -eq 0 ]; then
-    CLJ_FLAGS+=-Sforce
+    CLJ_FLAGS=-Sforce
 fi
 
 clojure $CLJ_FLAGS -A:uberdeps --main-class ptc.start

--- a/ops/build.sh
+++ b/ops/build.sh
@@ -1,13 +1,10 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
-# This script is used to compile the source code with AOT and
-# built it into an executable UberJar. For more information,
-# please check here:
-# - https://clojure.org/guides/deps_and_cli#aot_compilation
-# - https://github.com/tonsky/uberdeps
+# Build Uberjar with --main-class option. See for more
+# information, see https://github.com/tonsky/uberdeps
 
-# 1. Aot compile
-clj -e "(compile 'ptc.start)"
+if [ ${USE_CPCACHE-1} -eq 0 ]; then
+    CLJ_FLAGS+=-Sforce
+fi
 
-# 2. Uberjar with --main-class option
-clojure -A:uberdeps --main-class ptc.start
+clojure $CLJ_FLAGS -A:uberdeps --main-class ptc.start

--- a/ops/build.sh
+++ b/ops/build.sh
@@ -3,8 +3,4 @@
 # Build Uberjar with --main-class option. See for more
 # information, see https://github.com/tonsky/uberdeps
 
-if [ ${USE_CPCACHE-1} -eq 0 ]; then
-    CLJ_FLAGS=-Sforce
-fi
-
-clojure $CLJ_FLAGS -A:uberdeps --main-class ptc.start
+clojure -Sforce -A:uberdeps --main-class ptc.start

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+UNSET="\033[0m"
+BRIGHT_RED="\033[0;91m"
+BOLD="\033[1m"
+
+THIS=$(basename ${0})
+JAR=$PWD/target/push-to-cloud-service.jar
+
+bold() {
+    echo -e "${BOLD}${1}${UNSET}"
+}
+
+red() {
+    echo -e "${BRIGHT_RED}${1}${UNSET}"
+}
+
+error() {
+    local message=${1}
+    echo -e "$(bold ${THIS}:) $(red $(bold error:)) $message" 1>&2
+
+    local details=${2}
+    if [ -n "$details" ]; then
+        echo -e "$(bold ${THIS}:) $details" 1>&2
+    fi
+}
+
+if [ ! -e ${JAR} ]; then
+    error "no such file: push-to-cloud-service.jar" \
+          "run build.sh before deploying Push-To-Cloud"
+    exit 1
+fi
+
+error "failed to deploy - not implemented"
+exit 1

--- a/ops/deploy.sh
+++ b/ops/deploy.sh
@@ -1,35 +1,26 @@
 #!/usr/bin/env bash
 
-UNSET="\033[0m"
-BRIGHT_RED="\033[0;91m"
-BOLD="\033[1m"
-
 THIS=$(basename ${0})
 JAR=$PWD/target/push-to-cloud-service.jar
 
-bold() {
-    echo -e "${BOLD}${1}${UNSET}"
-}
-
-red() {
-    echo -e "${BRIGHT_RED}${1}${UNSET}"
-}
+bold() { printf '\e[1;1m%-6s\e[m\n' "$*"; }
+red() { printf '\e[1;91m%-6s\e[m\n' "$*"; }
 
 error() {
     local message=${1}
-    echo -e "$(bold ${THIS}:) $(red $(bold error:)) $message" 1>&2
+    echo -e $(bold ${THIS}:) $(red $(bold 'error:')) $message 1>&2
 
     local details=${2}
-    if [ -n "$details" ]; then
-        echo -e "$(bold ${THIS}:) $details" 1>&2
+    if [ -n "${details}" ]; then
+        echo -e $(bold ${THIS}:) $details 1>&2
     fi
 }
 
 if [ ! -e ${JAR} ]; then
-    error "no such file: push-to-cloud-service.jar" \
-          "run build.sh before deploying Push-To-Cloud"
+    error 'no such file: push-to-cloud-service.jar' \
+          'run build.sh before deploying Push-To-Cloud'
     exit 1
 fi
 
-error "failed to deploy - not implemented"
+error 'failed to deploy - not implemented'
 exit 1


### PR DESCRIPTION
### Purpose
[We want to automate deployment of PTC on prem](https://broadinstitute.atlassian.net/browse/GH-770).
By adding the script, I've been able to write the jenkins build/deploy job in dsp-jenkins. We can complete this implementation later.

### Changes
- Add mock deploy script. This tests that the .jar file is in the expected location and then errors because it's not clear to me what deployment means yet.
- Change build to not use the class path cache. this causes failures when building in docker as the libraries downloaded in build are deleted leaving the cache stale (note that dependencies are added to the uberjar)

This change is just to facilitate https://github.com/broadinstitute/dsp-jenkins/pull/398
