### PR TITLE
alter build script to run tests on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,16 @@
 # Clojure
-.cpcache
-/.nrepl-port
-/.classpath
-/target
+.cpcache/
+.classpath/
+.nrepl-port/
+target/
 
 # System
 .DS_Store
 
 # IDEs
-/.vscode
-/.idea
+.idea/
+.vscode/
 push-to-cloud-service.iml
+
+# Derived Files
+derived/

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,13 @@
 # Clojure
-.cpcache/
-.classpath/
-.nrepl-port/
-target/
+.cpcache
+/.nrepl-port
+/.classpath
+/target
 
 # System
 .DS_Store
 
 # IDEs
-.idea/
-.vscode/
+/.vscode
+/.idea
 push-to-cloud-service.iml
-
-# Derived Files
-derived/

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ The project structure is shown as above, you add new entries to `deps.edn`
 to introduce a new dependency, add new modules to `src/` and implement new
 test cases to `test/`.
 
+## Build
+
+To build an executable [Uber Jar with AOT compilation](https://clojure.org/guides/deps_and_cli#aot_compilation),
+simply run:
+
+```bash
+$ clojure -A:build
+```
+
+The JAR produced by can be run with
+`java -jar target/push-to-cloud-service.jar`, which will invoke the
+main function in the `start.clj` namespace, which is currently the only
+module with `:gen-class`.
+
 ### Code Style
 
 We use [`cljfmt`](https://github.com/weavejester/cljfmt) for a
@@ -70,25 +84,3 @@ To format the code, run:
 ```bash
 clojure -A:format
 ```
-
-## Build
-
-To build an executable [Uber Jar with AOT compilation](https://clojure.org/guides/deps_and_cli#aot_compilation),
-simply run:
-
-```bash
-$ ./ops/build.sh
-```
-
-By default, `build.sh` packages the sources and dependencies into
-`target/push-to-cloud-service.jar` and runs the unit tests. For more
-information, see the usage output:
-
-```bash
-$ ./ops/build.sh --help
-```
-
-The JAR produced by `build.sh` can be run with
-`java -jar target/push-to-cloud-service.jar`, which will invoke the
-main function in the `start.clj` namespace, which is currently the only
-module with `:gen-class`.

--- a/README.md
+++ b/README.md
@@ -77,12 +77,18 @@ To build an executable [Uber Jar with AOT compilation](https://clojure.org/guide
 simply run:
 
 ```bash
-bash ops/build.sh
+$ ./ops/build.sh
 ```
 
-which should output the detailed information about what are thrown into the
-Jar file while building the executable Jar file to `target/push-to-cloud-service.jar`.
+By default, `build.sh` packages the sources and dependencies into
+`target/push-to-cloud-service.jar` and runs the unit tests. For more
+information, see the usage output:
 
-You could run it with `java -jar target/push-to-cloud-service.jar`, which will invoke
-the main function in the `start.clj` namespace, which is currently the only module with
-`:gen-class`.
+```bash
+$ ./ops/build.sh --help
+```
+
+The JAR produced by `build.sh` can be run with
+`java -jar target/push-to-cloud-service.jar`, which will invoke the
+main function in the `start.clj` namespace, which is currently the only
+module with `:gen-class`.

--- a/deps.edn
+++ b/deps.edn
@@ -15,8 +15,8 @@
  :aliases {:test        {:extra-paths ["test"]
                          :extra-deps  {lambdaisland/kaocha               {:mvn/version "1.0.629"}}
                          :main-opts   ["-m" "kaocha.runner"]}
-           :uberdeps    {:extra-deps {uberdeps {:mvn/version "0.1.10"}}
-                         :main-opts  ["-m" "uberdeps.uberjar"]}
+           :build       {:extra-deps {uberdeps {:mvn/version "0.1.10"}}
+                         :main-opts  ["-m" "uberdeps.uberjar" "-main-classpath" "ptc.start"]}
            :lint        {:extra-deps {cljfmt {:mvn/version "0.6.7"}}
                          :main-opts  ["-m" "cljfmt.main" "check"]}
            :format      {:extra-deps {cljfmt {:mvn/version "0.6.7"}}

--- a/ops/build.sh
+++ b/ops/build.sh
@@ -67,7 +67,10 @@ do
 done
 
 when() {
-    [ "$1" -ne 0 ] && shift && "$@" || true
+    if [ "$1" -ne 0 ]; then
+        shift
+        "$@"
+    fi
 }
 
 info() {
@@ -82,7 +85,7 @@ doIO() {
 
 clean-outputs() {
     info '=> cleaning output directories'
-    doIO rm -rf target/ derived/
+    doIO rm -rf target/ derived/ .cpcache
 }
 
 make-ptc-jar() {

--- a/ops/build.sh
+++ b/ops/build.sh
@@ -1,112 +1,23 @@
 #!/usr/bin/env bash
-# Build Uberjar with --main-class option. See for more
-# information, see https://github.com/tonsky/uberdeps
+
+# Build push-to-cloud service jar without the classpath cache,
+# running build-time (unit) tests.
 
 set -e
-
-THIS=$(basename ${0})
-
-usage() {
-    cat <<EOF
-Usage:
-    $THIS [FLAGS]...
-
-Build push-to-cloud service jar, running build-time tests; see
-https://github.com/broadinstitute/push-to-cloud-service for more
-information.
-
-Flags:
-    --clean              clean output directories before build
-    --help               show this message
-    --no-classpath-cache recompute the classpath, don't cache
-    --no-tests           don't run build-time tests
-    --silent             don't output to stdout
-    --verbose            be verbose
-
-$THIS runs 'clojure \${CLOJURE_OPTS[@]}", where by default
-CLOJURE_OPTS is empty. You can override this to pass additional
-options and flags to clojure.
-EOF
-}
-
-CLEAN=0
-TEST=1
-SILENT=0
-VERBOSE=0
-
-while [ $# -gt 0 ];
-do
-    case "$1" in
-        --clean)
-            CLEAN=1
-            ;;
-        --help)
-            usage
-            exit 0
-            ;;
-        --no-classpath-cache)
-            CLOJURE_OPTS+=('-Sforce')
-            ;;
-        --no-tests)
-            TEST=0
-            ;;
-        --silent)
-            SILENT=1
-            ;;
-        --verbose)
-            VERBOSE=1
-            CLOJURE_OPTS+=('-Sverbose')
-            ;;
-        *)
-            echo "$THIS: unrecognized argument '$1'" >&2
-            echo "Try '$THIS --help' for more information." >&2
-            exit 1
-            ;;
-    esac
-    shift
-done
-
-when() {
-    if [ "$1" -ne 0 ]; then
-        shift
-        "$@"
-    fi
-}
 
 info() {
     local BOLD='\e[1;1m%-6s\e[m\n'
     printf $BOLD "$*"
 }
 
-doIO() {
-    when $VERBOSE echo "$*"
-    "$@"
-}
-
-clean-outputs() {
-    info '=> cleaning output directories'
-    doIO rm -rf target/ derived/ .cpcache
-}
-
-make-ptc-jar() {
-    info '=> building push-to-cloud-service.jar'
-    doIO mkdir -p 'derived'
-    doIO clojure "${CLOJURE_OPTS[@]}" -A:uberdeps -main-classpath ptc.start \
-        | tee 'derived/build.log' 2>&1
-}
-
-run-tests() {
-    info '=> running unit tests'
-    doIO mkdir -p 'derived/test'
-    doIO clojure "${CLOJURE_OPTS[@]}" -A:test unit \
-        | tee 'derived/test/unit.log' 2>&1
-}
+logged() { echo "$*"; "$@"; }
 
 main() {
-    when $CLEAN clean-outputs
-    make-ptc-jar
-    when $TEST run-tests
+    info '=> building push-to-cloud-service.jar'
+    logged clojure -Sforce -A:build
+
+    info '=> running unit tests'
+    logged clojure -Sforce -A:test unit
 }
 
-when $SILENT eval 'exec 1>/dev/null'
 main

--- a/ops/build.sh
+++ b/ops/build.sh
@@ -1,6 +1,109 @@
 #!/usr/bin/env bash
-
 # Build Uberjar with --main-class option. See for more
 # information, see https://github.com/tonsky/uberdeps
 
-clojure -Sforce -A:uberdeps --main-class ptc.start
+set -e
+
+THIS=$(basename ${0})
+
+usage() {
+    cat <<EOF
+Usage:
+    $THIS [FLAGS]...
+
+Build push-to-cloud service jar, running build-time tests; see
+https://github.com/broadinstitute/push-to-cloud-service for more
+information.
+
+Flags:
+    --clean              clean output directories before build
+    --help               show this message
+    --no-classpath-cache recompute the classpath, don't cache
+    --no-tests           don't run build-time tests
+    --silent             don't output to stdout
+    --verbose            be verbose
+
+$THIS runs 'clojure \${CLOJURE_OPTS[@]}", where by default
+CLOJURE_OPTS is empty. You can override this to pass additional
+options and flags to clojure.
+EOF
+}
+
+CLEAN=0
+TEST=1
+SILENT=0
+VERBOSE=0
+
+while [ $# -gt 0 ];
+do
+    case "$1" in
+        --clean)
+            CLEAN=1
+            ;;
+        --help)
+            usage
+            exit 0
+            ;;
+        --no-classpath-cache)
+            CLOJURE_OPTS+=('-Sforce')
+            ;;
+        --no-tests)
+            TEST=0
+            ;;
+        --silent)
+            SILENT=1
+            ;;
+        --verbose)
+            VERBOSE=1
+            CLOJURE_OPTS+=('-Sverbose')
+            ;;
+        *)
+            echo "$THIS: unrecognized argument '$1'" >&2
+            echo "Try '$THIS --help' for more information." >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+when() {
+    [ "$1" -ne 0 ] && shift && "$@" || true
+}
+
+info() {
+    local BOLD='\e[1;1m%-6s\e[m\n'
+    printf $BOLD "$*"
+}
+
+doIO() {
+    when $VERBOSE echo "$*"
+    "$@"
+}
+
+clean-outputs() {
+    info '=> cleaning output directories'
+    doIO rm -rf target/ derived/
+}
+
+make-ptc-jar() {
+    info '=> building push-to-cloud-service.jar'
+    doIO mkdir -p 'derived'
+    doIO clojure "${CLOJURE_OPTS[@]}" -A:uberdeps -main-classpath ptc.start \
+        | tee 'derived/build.log' 2>&1
+}
+
+run-tests() {
+    info '=> running unit tests'
+    doIO mkdir -p 'derived/test'
+    doIO clojure "${CLOJURE_OPTS[@]}" -A:test unit \
+        | tee 'derived/test/unit.log' 2>&1
+}
+
+main() {
+    when $CLEAN clean-outputs
+    make-ptc-jar
+    when $TEST run-tests
+}
+
+when $SILENT eval 'exec 1>/dev/null'
+main


### PR DESCRIPTION
### Purpose
https://broadinstitute.atlassian.net/browse/GH-810
When generating the .jar build artifact, we should run the unit tests, the outcome of which should affect the result of the build.

### Changes
Change `ops/build.sh` to run tests on build.
Added a number of flags to customise behaviour. In particular classpath cashing dramatically speeds up builds.

Puzzle:
It's not clear how to make `clojure` use a different `cache_dir` than `.cpcache`. Simply setting `CLJ_CACHE=/path/to/cache` doesn't work as `deps.edn` exists (see https://clojure.org/reference/deps_and_cli#_directories for more info)
