### PR TITLE
remove empty project.clj

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -17,7 +17,7 @@
                          :main-opts   ["-m" "kaocha.runner"]}
            :build       {:extra-deps {uberdeps {:mvn/version "0.1.10"}}
                          :main-opts  ["-m" "uberdeps.uberjar" "-main-classpath" "ptc.start"]}
-           :lint        {:extra-deps {cljfmt {:mvn/version "0.6.7"}}
+           :lint        {:extra-deps {cljfmt {:mvn/version "0.6.8"}}
                          :main-opts  ["-m" "cljfmt.main" "check"]}
            :format      {:extra-deps {cljfmt {:mvn/version "0.6.7"}}
                          :main-opts  ["-m" "cljfmt.main" "fix"]}}

--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,0 @@
-;; We need this empty file for cljfmt
-;; until they release a new bug fix for:
-;; https://github.com/weavejester/cljfmt/issues/192


### PR DESCRIPTION
### Purpose
Rex noted that we no longer need an empty `project.clj` now that [the bug`cljfmat` has been squished.](https://github.com/weavejester/cljfmt/issues/192)

### Changes
bump `cljfmat` dependency to 0.6.8
delete `project.clj`

### Review Instructions
