### PR TITLE
[GH-859] Set jar to multi-release to remove a warning message

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -19,7 +19,8 @@
                          :extra-deps  {lambdaisland/kaocha               {:mvn/version "1.0.629"}}
                          :main-opts   ["-m" "kaocha.runner"]}
            :build       {:extra-deps {uberdeps {:mvn/version "0.1.10"}}
-                         :main-opts  ["-e" "(compile,'ptc.start)"  "-m" "uberdeps.uberjar" "--main-class" "ptc.start"]}
+                         :main-opts  ["-e" "(compile,'ptc.start)"
+                                      "-m" "uberdeps.uberjar" "--main-class" "ptc.start" "--multi-release"]}
            :lint        {:extra-deps {cljfmt {:mvn/version "0.6.8"}}
                          :main-opts  ["-m" "cljfmt.main" "check"]}
            :format      {:extra-deps {cljfmt {:mvn/version "0.6.8"}}


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-859
- We don't like errant warning messages and setting this option removes one.
- This is the PTC incarnate of [this WFL PR](https://github.com/broadinstitute/wfl/pull/75)

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Set the jar to multi-release so Log4j2 is happier and doesn't print a warning

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- `clojure -A:build` followed by `java -jar target/push-to-cloud-service.jar` doesn't print a warning message complaining about a reflection issue
  - Granted, PTC doesn't have help text so the above will absolutely spew exceptions onto your console, but the first line shouldn't complain about a reflection issue anymore
