### PR TITLE
fix syntax error in release.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,8 +91,8 @@ jobs:
 
       - name: package
         env:
-          VERSION=${{ github.event.inputs.version }}
-          NOTE=${{ github.event.input.release_note }}
+          VERSION: ${{ github.event.inputs.version }}
+          NOTE: ${{ github.event.input.release_note }}
         run: contrib/package.sh
 
       - name: create release


### PR DESCRIPTION
### Purpose
I broke the release pipeline in https://github.com/broadinstitute/push-to-cloud-service/commit/807b0c3bc7c84ba27c5cd9f2fb928993a74f00d3

### Changes
Fix syntax error 

Sadly I can't test this in a fork as I don't have the necessary secrets to run the tests.
