### PR TITLE
remove gcs http requests fom product code

### DIFF
--- a/src/ptc/util/jms.clj
+++ b/src/ptc/util/jms.clj
@@ -2,7 +2,6 @@
   "Frob JMS messages into upload actions and workflow parameters."
   (:require [clojure.data.json :as json]
             [clojure.string    :as str]
-            [ptc.util.gcs      :as gcs]
             [ptc.util.misc     :as misc]))
 
 (def cromwell

--- a/test/ptc/integration/integration_test.clj
+++ b/test/ptc/integration/integration_test.clj
@@ -1,9 +1,8 @@
 (ns ptc.integration.integration-test
   (:require [clojure.test  :refer [deftest is testing]]
             [clojure.edn   :as edn]
-            [clojure.walk  :as walk]
             [ptc.start     :as start]
-            [ptc.util.gcs  :as gcs]
+            [ptc.tools.gcs  :as gcs]
             [ptc.util.jms  :as jms])
   (:import [org.apache.activemq ActiveMQSslConnectionFactory]
            (java.util UUID)))

--- a/test/ptc/integration/jms_test.clj
+++ b/test/ptc/integration/jms_test.clj
@@ -7,7 +7,7 @@
             [clojure.string    :as str]
             [clojure.test      :refer [deftest is testing]]
             [ptc.start         :as start]
-            [ptc.util.gcs      :as gcs]
+            [ptc.tools.gcs      :as gcs]
             [ptc.util.jms      :as jms]
             [ptc.util.misc     :as misc])
   (:import [java.util UUID]

--- a/test/ptc/tools/gcs.clj
+++ b/test/ptc/tools/gcs.clj
@@ -1,4 +1,4 @@
-(ns ptc.util.gcs
+(ns ptc.tools.gcs
   "Utility functions for Google Cloud Storage shared across this program."
   (:require [clojure.pprint    :refer [pprint]]
             [clojure.data.json :as json]

--- a/test/ptc/unit/start_test.clj
+++ b/test/ptc/unit/start_test.clj
@@ -1,7 +1,6 @@
 (ns ptc.unit.start-test
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.edn  :as edn]
-            [clojure.walk :as walk]
             [ptc.start    :as start]
             [ptc.util.jms :as jms])
   (:import [org.apache.activemq ActiveMQSslConnectionFactory]))

--- a/test/ptc/unit/util_test.clj
+++ b/test/ptc/unit/util_test.clj
@@ -1,8 +1,7 @@
 (ns ptc.unit.util-test
   (:require [clojure.test  :refer [deftest is testing]]
             [ptc.util.misc :as misc]
-            [ptc.util.gcs  :as gcs]
-            [clojure.edn   :as edn]))
+            [ptc.tools.gcs  :as gcs]))
 
 (deftest test-notify-everyone-on-the-list-with-message
   (letfn [(notify [msg to-list]

--- a/tests.edn
+++ b/tests.edn
@@ -7,5 +7,5 @@
                         :kaocha/ns-patterns ["ptc\\.integration\\..*-test$"]}]
 
      :color?          true
-     :reporter        [kaocha.report.progress/report]
+     :reporter        [kaocha.report/documentation]
      :capture-output? true}


### PR DESCRIPTION
### Purpose
PTC should only be using `gsutil` to communicate with GCS. Right now, there's a module `gcs` that makes https requests with custom auth headers. We probably shouldn't ship this.

### Changes
Move `ptc.util.gcs` into a test namespace so it can be used in testing code.
Remove knowledge of `gcs` from product code.