### PR TITLE
hard code runas user

### DIFF
--- a/in/install.sh.in
+++ b/in/install.sh.in
@@ -20,6 +20,7 @@ main() {
 
     sed "s|%PTC_BIN|${LIB_DIR}/push-to-cloud.jar|" \
         in/unit/push-to-cloud.service.in > ${UNIT_DIR}/push-to-cloud.service \
+        && sed -i '/User=ptc/d' ${UNIT_DIR}/push-to-cloud.service \
         && systemctl --user daemon-reload
 }
 

--- a/in/unit/push-to-cloud.service.in
+++ b/in/unit/push-to-cloud.service.in
@@ -4,12 +4,11 @@ After=network.target
 StartLimitIntervalSec=0
 
 [Service]
-EnvironmentFile=-/etc/sysconfig/push-to-cloud
 ExecStart=java -cp %PTC_BIN clojure.main -m ptc.start
-Restart=Always
+Restart=always
 RestartSec=1
 SuccessExitStatus=143
-User=${USER}
+User=ptc
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
### Purpose
The EnvironmentFile does not function as I thought it did.  Use of EnvironmentFile is actually discouraged. The runas user is now hard coded as "ptc".  This user will be created as part of the rpm creation.

- No ticket is linked to this PR.

### Changes
Remove EnvironmentFile config and hard code runas user to "ptc".  
Also changed case of Restart specifier.

### Review Instructions

- No instructions.
