### PR TITLE
[GH-881] Let PTC push-to-cloud by default

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,4 +1,4 @@
-{:paths   ["src" "classes"]
+{:paths   ["src" "classes" "resources"]
 
  :deps    {org.clojure/clojure                       {:mvn/version "1.10.1"}
            org.clojure/data.json                     {:mvn/version "1.0.0"}

--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -18,6 +18,7 @@ Its syntax is given by https://logging.apache.org/log4j/2.x/manual/configuration
         </Console>
     </Appenders>
     <Loggers>
+        <Logger name="org.apache.activemq" level="ERROR"/>
         <Root level="DEBUG">
             <AppenderRef ref="stdout"/>
             <AppenderRef ref="stderr"/>

--- a/src/ptc/start.clj
+++ b/src/ptc/start.clj
@@ -99,7 +99,7 @@
                  peeked))))
        (recur counter))))
   ([connection queue]
-   (let [ptc-bucket-name (or (System/getenv "ptc_bucket_name") "broad-gotc-dev-zero-test")
+   (let [ptc-bucket-name (or (System/getenv "PTC_BUCKET_NAME") "broad-gotc-dev-zero-test")
          push-to (misc/gs-url ptc-bucket-name)
          upload-sample! (fn [msg] (jms/handle-message push-to msg))]
      (listen-and-consume-from-queue upload-sample! connection queue))))
@@ -117,6 +117,6 @@
 
 (defn -main
   []
-  (let [environment (or (System/getenv "environment") "dev")]
+  (let [environment (or (System/getenv "ENVIRONMENT") "dev")]
     (log/infof "%s starting up on %s" ptc/the-name environment)
     (message-loop environment)))

--- a/src/ptc/start.clj
+++ b/src/ptc/start.clj
@@ -86,10 +86,10 @@
                (if (task-push-to! peeked)
                  (let [consumed (jms/ednify (consume connection queue))]
                    (log/infof "Task complete, consumed message %s" counter)
-                   (if (not (= ednified-peeked consumed))
+                   (if (not (misc/message-ids-equal? ednified-peeked consumed))
                      (log/warnf
                       (str/join \space ["Messages differ:"
-                                        (pprint (data/diff ednified-peeked consumed))])))
+                                        (with-out-str (pprint (data/diff ednified-peeked consumed)))])))
                    (recur (inc counter)))
                  (do
                    (log/errorf

--- a/src/ptc/start.clj
+++ b/src/ptc/start.clj
@@ -87,15 +87,15 @@
                  (log/infof "Task complete, consumed message %s" counter)
                  (if (not (misc/message-ids-equal? peeked consumed))
                    (log/warnf
-                     (str/join \space ["Messages differ:"
-                                       (with-out-str (pprint (data/diff peeked consumed)))])))
+                    (str/join \space ["Messages differ:"
+                                      (with-out-str (pprint (data/diff peeked consumed)))])))
                  (recur (inc counter)))
                (do
                  (log/errorf
-                   (str/join
-                     \space ["Task returned nil/false,"
-                             "not consuming message %s and instead exiting"])
-                   counter)
+                  (str/join
+                   \space ["Task returned nil/false,"
+                           "not consuming message %s and instead exiting"])
+                  counter)
                  peeked))))
        (recur counter))))
   ([connection queue]

--- a/src/ptc/start.clj
+++ b/src/ptc/start.clj
@@ -49,9 +49,9 @@
     (let [queue (.createQueue session queue)]
       (with-open [browser (.createBrowser session queue)]
         (.start connection)
-        (log/infof "Browser: attempting to peek message.")
+        (log/debugf "Browser: attempting to peek message.")
         (let [msg-enum (.getEnumeration browser)]
-          (while (not (.hasMoreElements msg-enum))
+          (when (not (.hasMoreElements msg-enum))
             (Thread/sleep 10000))
           (.nextElement msg-enum))))))
 
@@ -80,6 +80,7 @@
   ([task! connection queue push-to]
    (loop [counter 0]
      (if-let [peeked (peek-message connection queue)]
+       ; to avoid NPE on ednify
        (let [peeked (jms/ednify peeked)]
          (do (log/infof "Peeked message %s: %s" counter peeked)
              (if (task! push-to peeked)

--- a/src/ptc/start.clj
+++ b/src/ptc/start.clj
@@ -103,7 +103,7 @@
    (listen-and-consume-from-queue jms/handle-message connection queue push-to)))
 
 (defn message-loop
-  "Loop with a JMS connection in ENVIRONMENT that pushes data to PTC-BUCKET-NAME."
+  "Loop with a JMS connection in ENVIRONMENT that pushes data to PUSH-TO."
   [environment push-to]
   (while true
     (try

--- a/src/ptc/util/jms.clj
+++ b/src/ptc/util/jms.clj
@@ -2,7 +2,6 @@
   "Frob JMS messages into upload actions and workflow parameters."
   (:require [clojure.data.json :as json]
             [clojure.string    :as str]
-            [ptc.util.gcs      :as gcs]
             [ptc.util.misc     :as misc]))
 
 (def cromwell

--- a/src/ptc/util/jms.clj
+++ b/src/ptc/util/jms.clj
@@ -162,6 +162,9 @@
         (assoc headers ::Properties (update keyed :payload unjsonify))
         headers))))
 
+(comment
+  (ednify nil))
+
 (defn encode
   "Encode EDN MESSAGE ::Properties :payload for a PTC JMS message."
   [{:keys [::Properties] :as message}]
@@ -173,9 +176,9 @@
 (def missing-keys-message "Missing JMS keys:") ; for tests
 
 (defn handle-message
-  "Throw or push to cloud at PREFIX all the files for un-ednified JMS message."
+  "Throw or push to cloud at PREFIX all the files for ednified JMS message."
   [prefix jms]
-  (let [workflow (get-in (ednify jms) [::Properties :payload :workflow])
+  (let [workflow (get-in jms [::Properties :payload :workflow])
         missing? (fn [k] (when (nil? (k workflow)) k))
         missing (keep missing? required-jms-keys)]
     (when (seq missing)

--- a/src/ptc/util/jms.clj
+++ b/src/ptc/util/jms.clj
@@ -173,7 +173,7 @@
 (def missing-keys-message "Missing JMS keys:") ; for tests
 
 (defn handle-message
-  "Throw or push to cloud at PREFIX all the files for JMS message."
+  "Throw or push to cloud at PREFIX all the files for un-ednified JMS message."
   [prefix jms]
   (let [workflow (get-in (ednify jms) [::Properties :payload :workflow])
         missing? (fn [k] (when (nil? (k workflow)) k))

--- a/src/ptc/util/jms.clj
+++ b/src/ptc/util/jms.clj
@@ -162,9 +162,6 @@
         (assoc headers ::Properties (update keyed :payload unjsonify))
         headers))))
 
-(comment
-  (ednify nil))
-
 (defn encode
   "Encode EDN MESSAGE ::Properties :payload for a PTC JMS message."
   [{:keys [::Properties] :as message}]

--- a/src/ptc/util/misc.clj
+++ b/src/ptc/util/misc.clj
@@ -116,3 +116,9 @@
   "Parse the json string STR into a keyword-string map"
   [str]
   (json/read-str str :key-fn keyword))
+
+(defn message-ids-equal?
+  "True when the IDs of MESSAGES are the same. Otherwise false."
+  [& messages]
+  (or (empty? messages)
+    (apply = (map :properties messages))))

--- a/src/ptc/util/misc.clj
+++ b/src/ptc/util/misc.clj
@@ -96,3 +96,18 @@
 (def uuid-nil
   "The nil UUID."
   (UUID/fromString "00000000-0000-0000-0000-000000000000"))
+
+(defn gs-url
+  "Format BUCKET and OBJECT into a gs://bucket/object URL."
+  ([bucket object]
+   (when-not (and (string?        bucket)
+                  (seq            bucket)
+                  (not-any? #{\/} bucket))
+     (let [fmt "The bucket (%s) must be a non-empty string."
+           msg (format fmt bucket)]
+       (throw (IllegalArgumentException. msg))))
+   (if (nil? object)
+     (str "gs://" bucket)
+     (str "gs://" bucket "/" object)))
+  ([bucket]
+   (gs-url bucket nil)))

--- a/src/ptc/util/misc.clj
+++ b/src/ptc/util/misc.clj
@@ -121,4 +121,4 @@
   "True when the IDs of MESSAGES are the same. Otherwise false."
   [& messages]
   (or (empty? messages)
-    (apply = (map :properties messages))))
+      (apply = (map :properties messages))))

--- a/test/data/test_msg_diff.edn
+++ b/test/data/test_msg_diff.edn
@@ -1,4 +1,4 @@
-; Like test_msg.edn but with different memory address and timestamp (so not conceptually equal to test_msg.edn)
+; Like test_msg.edn but with different memory address, timestamp and chipWellBarcode (so not conceptually equal to test_msg.edn)
 {:headers {:readOnlyBody true,
            :redeliveryCounter 0,
            :arrival 0,
@@ -8,7 +8,7 @@
            :size 2810,
            :droppable false,
            :compressed false,
-           :brokerOutTime 1597344353047,
+           :brokerOutTime 1597344366123,
            :priority 4,
            :groupSequence 0,
            :readOnlyProperties true,
@@ -34,7 +34,7 @@
                                    :productName "Infinium Exome V1_A",
                                    :chipName "HumanExome-12v1-1_A",
                                    :redIDatPath "/bogus/path/to/push-to-cloud-service/test/data/bogus-red.idat",
-                                   :chipWellBarcode "7991775143_R01C01",
+                                   :chipWellBarcode "7991775143_R01C02",
                                    :productType "aou_array",
                                    :haplotypeMap "bogus-haplotype-map.txt",
                                    :productOrderId "bogus-productOrderId",

--- a/test/data/test_msg_same.edn
+++ b/test/data/test_msg_same.edn
@@ -1,4 +1,4 @@
-; Like test_msg.edn but with different memory address and timestamp (so not conceptually equal to test_msg.edn)
+; Like test_msg.edn but with only different memory address, timestamp (so conceptually equal to test_msg.edn)
 {:headers {:readOnlyBody true,
            :redeliveryCounter 0,
            :arrival 0,
@@ -8,7 +8,7 @@
            :size 2810,
            :droppable false,
            :compressed false,
-           :brokerOutTime 1597344353047,
+           :brokerOutTime 1597344366123,
            :priority 4,
            :groupSequence 0,
            :readOnlyProperties true,
@@ -17,7 +17,7 @@
            :producerId "ID:wm8d7-5e4-56463-1597342355067-1:1:1:1",
            :destination "queue://wfl.broad.pushtocloud.enqueue.dev",
            :commandId 6,
-           :brokerInTime 1597342355456,
+           :brokerInTime 1597344366123,
            :marshalledProperties "org.apache.activemq.util.ByteSequence@3ba3f40d"},
  :properties {:action "start",
               :payload {:Zamboni {:workflow "IlluminaArraysWorkflow",

--- a/test/ptc/integration/integration_test.clj
+++ b/test/ptc/integration/integration_test.clj
@@ -30,13 +30,12 @@
 
 (deftest integration
   (let [prefix (str "test/" (UUID/randomUUID))
-        properties (::jms/Properties (jms/encode message))
-        push-to    (misc/gs-url bucket prefix)]
-    (letfn [(task [push-to _]
+        properties (::jms/Properties (jms/encode message))]
+    (letfn [(task [_]
               (try
                 (testing "end-to-end: "
                   (testing "upload a file to the bucket"
-                    (let [upload (gcs/upload-file "deps.edn" push-to)]
+                    (let [upload (gcs/upload-file "deps.edn" bucket prefix)]
                       (is (= prefix (:name upload)))
                       (is (= bucket (:bucket upload)))
                       (is (= [upload] (gcs/list-objects bucket prefix))))))
@@ -44,21 +43,20 @@
               false)
             (flow [connection queue]
               (start/produce connection queue "text" properties)
-              (start/listen-and-consume-from-queue task connection queue push-to))]
+              (start/listen-and-consume-from-queue task connection queue))]
       (testing "Message is not nil and can be properly read"
         (if-let [msg (with-test-jms-connection flow)]
           (is (= message (select-keys msg [::jms/Properties])))
           (is false))))))
 
 (deftest peeking
-  (let [properties (::jms/Properties (jms/encode message))
-        push-to    (misc/gs-url bucket "")]
-    (letfn [(task [push-to message] (is push-to) (is message) false)]
+  (let [properties (::jms/Properties (jms/encode message))]
+    (letfn [(task [message] (is message) false)]
       (with-test-jms-connection
         (fn [connection queue]
           (testing "Message given to task isn't nil"
             (start/produce connection queue "text" properties)
-            (start/listen-and-consume-from-queue task connection queue push-to))
+            (start/listen-and-consume-from-queue task connection queue))
           (testing "The message was only peeked and can still be consumed"
             (let [msg (jms/ednify (start/consume connection queue))]
               (testing "Message is not nil and can be properly read"

--- a/test/ptc/integration/integration_test.clj
+++ b/test/ptc/integration/integration_test.clj
@@ -1,9 +1,8 @@
 (ns ptc.integration.integration-test
   (:require [clojure.test  :refer [deftest is testing]]
             [clojure.edn   :as edn]
-            [clojure.walk  :as walk]
             [ptc.start     :as start]
-            [ptc.util.gcs  :as gcs]
+            [ptc.tools.gcs  :as gcs]
             [ptc.util.jms  :as jms])
   (:import [org.apache.activemq ActiveMQSslConnectionFactory]
            (java.util UUID)))

--- a/test/ptc/integration/integration_test.clj
+++ b/test/ptc/integration/integration_test.clj
@@ -3,6 +3,7 @@
             [clojure.edn   :as edn]
             [ptc.start     :as start]
             [ptc.tools.gcs  :as gcs]
+            [ptc.util.misc  :as misc]
             [ptc.util.jms  :as jms])
   (:import [org.apache.activemq ActiveMQSslConnectionFactory]
            (java.util UUID)))
@@ -29,12 +30,13 @@
 
 (deftest integration
   (let [prefix (str "test/" (UUID/randomUUID))
-        properties (::jms/Properties (jms/encode message))]
-    (letfn [(task [_]
+        properties (::jms/Properties (jms/encode message))
+        push-to    (misc/gs-url bucket prefix)]
+    (letfn [(task [push-to _]
               (try
                 (testing "end-to-end: "
                   (testing "upload a file to the bucket"
-                    (let [upload (gcs/upload-file "deps.edn" bucket prefix)]
+                    (let [upload (gcs/upload-file "deps.edn" push-to)]
                       (is (= prefix (:name upload)))
                       (is (= bucket (:bucket upload)))
                       (is (= [upload] (gcs/list-objects bucket prefix))))))
@@ -42,20 +44,21 @@
               false)
             (flow [connection queue]
               (start/produce connection queue "text" properties)
-              (start/listen-and-consume-from-queue task connection queue))]
+              (start/listen-and-consume-from-queue task connection queue push-to))]
       (testing "Message is not nil and can be properly read"
         (if-let [msg (with-test-jms-connection flow)]
           (is (= message (select-keys msg [::jms/Properties])))
           (is false))))))
 
 (deftest peeking
-  (let [properties (::jms/Properties (jms/encode message))]
-    (letfn [(task [message] (is message) false)]
+  (let [properties (::jms/Properties (jms/encode message))
+        push-to    (misc/gs-url bucket "")]
+    (letfn [(task [push-to message] (is push-to) (is message) false)]
       (with-test-jms-connection
         (fn [connection queue]
           (testing "Message given to task isn't nil"
             (start/produce connection queue "text" properties)
-            (start/listen-and-consume-from-queue task connection queue))
+            (start/listen-and-consume-from-queue task connection queue push-to))
           (testing "The message was only peeked and can still be consumed"
             (let [msg (jms/ednify (start/consume connection queue))]
               (testing "Message is not nil and can be properly read"

--- a/test/ptc/integration/jms_test.clj
+++ b/test/ptc/integration/jms_test.clj
@@ -30,7 +30,7 @@
   "
   [uri & body]
   `(let [name# (str "ptc-test-" (UUID/randomUUID))
-         ~uri (gcs/gs-url gcs-test-bucket name#)]
+         ~uri (misc/gs-url gcs-test-bucket name#)]
      (try
        ~@body
        (finally
@@ -137,8 +137,8 @@
                           (assoc-in where n)
                           jms/encode
                           ::jms/Properties))]
-      (start/with-push-to-cloud-jms-connection "dev"
-        (fn [connection queue]
+      (start/with-push-to-cloud-jms-connection "dev" "bogus-bucket-url"
+        (fn [connection queue _]
           (run! (partial start/produce connection queue blame)
                 (map make (range 1 (inc n)))))))))
 

--- a/test/ptc/integration/jms_test.clj
+++ b/test/ptc/integration/jms_test.clj
@@ -7,7 +7,7 @@
             [clojure.string    :as str]
             [clojure.test      :refer [deftest is testing]]
             [ptc.start         :as start]
-            [ptc.util.gcs      :as gcs]
+            [ptc.tools.gcs      :as gcs]
             [ptc.util.jms      :as jms]
             [ptc.util.misc     :as misc])
   (:import [java.util UUID]

--- a/test/ptc/integration/jms_test.clj
+++ b/test/ptc/integration/jms_test.clj
@@ -137,8 +137,8 @@
                           (assoc-in where n)
                           jms/encode
                           ::jms/Properties))]
-      (start/with-push-to-cloud-jms-connection "dev" "bogus-bucket-url"
-        (fn [connection queue _]
+      (start/with-push-to-cloud-jms-connection "dev"
+        (fn [connection queue]
           (run! (partial start/produce connection queue blame)
                 (map make (range 1 (inc n)))))))))
 

--- a/test/ptc/integration/jms_test.clj
+++ b/test/ptc/integration/jms_test.clj
@@ -106,7 +106,7 @@
                            "BAD" (::jms/Properties (jms/encode bad)))
             (let [msg (start/consume connection queue)]
               (is (thrown-with-msg? IllegalArgumentException missing
-                                    (jms/handle-message folder msg)))
+                                    (jms/handle-message folder (jms/ednify msg))))
               (is (empty? (->> folder
                                gcs/parse-gs-url
                                (apply gcs/list-objects))))))
@@ -114,7 +114,7 @@
             (start/produce connection queue
                            "GOOD" (::jms/Properties (jms/encode good)))
             (let [msg (start/consume connection queue)
-                  [params ptc] (jms/handle-message folder msg)
+                  [params ptc] (jms/handle-message folder (jms/ednify msg))
                   {:keys [notifications] :as request} (gcs-edn ptc)
                   pushed (push (first notifications))
                   gcs (list-gcs-folder folder)

--- a/test/ptc/tools/gcs.clj
+++ b/test/ptc/tools/gcs.clj
@@ -1,4 +1,4 @@
-(ns ptc.util.gcs
+(ns ptc.tools.gcs
   "Utility functions for Google Cloud Storage shared across this program."
   (:require [clojure.pprint    :refer [pprint]]
             [clojure.data.json :as json]

--- a/test/ptc/tools/gcs.clj
+++ b/test/ptc/tools/gcs.clj
@@ -41,17 +41,6 @@
       (throw (IllegalArgumentException. (format "Bad GCS URL: '%s'" url))))
     [bucket (or object "")]))
 
-(defn gs-url
-  "Format BUCKET and OBJECT into a gs://bucket/object URL."
-  [bucket object]
-  (when-not (and (string?        bucket)
-                 (seq            bucket)
-                 (not-any? #{\/} bucket))
-    (let [fmt "The bucket (%s) must be a non-empty string."
-          msg (format fmt bucket)]
-      (throw (IllegalArgumentException. msg))))
-  (str "gs://" bucket "/" object))
-
 (defn list-objects
   "The objects in BUCKET with PREFIX in a lazy sequence."
   ([bucket prefix]

--- a/test/ptc/unit/start_test.clj
+++ b/test/ptc/unit/start_test.clj
@@ -1,7 +1,6 @@
 (ns ptc.unit.start-test
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.edn  :as edn]
-            [clojure.walk :as walk]
             [ptc.start    :as start]
             [ptc.util.jms :as jms])
   (:import [org.apache.activemq ActiveMQSslConnectionFactory]))

--- a/test/ptc/unit/util_test.clj
+++ b/test/ptc/unit/util_test.clj
@@ -1,5 +1,6 @@
 (ns ptc.unit.util-test
   (:require [clojure.test  :refer [deftest is testing]]
+            [clojure.edn   :as edn]
             [ptc.util.misc :as misc]
             [ptc.tools.gcs  :as gcs]))
 
@@ -29,3 +30,21 @@
       (is (thrown? IllegalArgumentException (gcs/parse-gs-url "gs:")))
       (is (thrown? IllegalArgumentException (gcs/parse-gs-url "gs:/b/o")))
       (is (thrown? IllegalArgumentException (gcs/parse-gs-url "gs:///o/"))))))
+
+(deftest test-message-id-equality
+  (let [test-msg (edn/read-string (slurp "test/data/test_msg.edn"))
+        test-msg-different (edn/read-string (slurp "test/data/test_msg_diff.edn"))
+        test-msg-same (edn/read-string (slurp "test/data/test_msg_same.edn"))]
+    (testing "message ID equality"
+      (testing "true with no arguments"
+        (is (misc/message-ids-equal?)))
+      (testing "true with one argument"
+        (is (misc/message-ids-equal? test-msg)))
+      (testing "test_msg equal to itself"
+        (is (misc/message-ids-equal? test-msg test-msg)))
+      (testing "test_msg equal to a different message with same properties"
+        (is (misc/message-ids-equal? test-msg test-msg-same)))
+      (testing "test_msg not equal to different message with different properties"
+        (is (not (misc/message-ids-equal? test-msg test-msg-different))))
+      (testing "not equal even if only one argument isn't"
+        (is (not (misc/message-ids-equal? test-msg test-msg test-msg-different)))))))

--- a/test/ptc/unit/util_test.clj
+++ b/test/ptc/unit/util_test.clj
@@ -1,8 +1,7 @@
 (ns ptc.unit.util-test
   (:require [clojure.test  :refer [deftest is testing]]
             [ptc.util.misc :as misc]
-            [ptc.util.gcs  :as gcs]
-            [clojure.edn   :as edn]))
+            [ptc.tools.gcs  :as gcs]))
 
 (deftest test-notify-everyone-on-the-list-with-message
   (letfn [(notify [msg to-list]

--- a/tests.edn
+++ b/tests.edn
@@ -7,5 +7,5 @@
                         :kaocha/ns-patterns ["ptc\\.integration\\..*-test$"]}]
 
      :color?          true
-     :reporter        [kaocha.report.progress/report]
+     :reporter        [kaocha.report/documentation]
      :capture-output? true}


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-881

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Let PTC push-to-cloud by default. Also teach it to read bucket from env var.
- Move the `gs-url` from the deprecated `gcs` module to the `misc` module.
- Functions in `start` module now accepts a new `push-to` gs-url argument.
- Update/fix some tests.
- Revert some changes @tbl3rd has done:
    - `peek-message` should not block but rather sleep and wake each loop, since the queue browser is a immutable snapshot.
    - re-implement a message comparator so timestamps and memory addresses won't break message comparison.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- `clojure -m ptc.start` and in a separate process, run `clojure -A:queue 2` as you wish.
