### PR TITLE
fetch non-secrets from environment. refactor to only query vault once.

### DIFF
--- a/src/ptc/start.clj
+++ b/src/ptc/start.clj
@@ -14,12 +14,12 @@
   "Create a javax.jms.QueueConnection to an ActiveMQ server"
   ([url username password]
    (->
-     (new ActiveMQSslConnectionFactory url)
-     (.createQueueConnection username password)))
+    (new ActiveMQSslConnectionFactory url)
+    (.createQueueConnection username password)))
   ([url]
    (->
-     (new ActiveMQSslConnectionFactory url)
-     (.createQueueConnection))))
+    (new ActiveMQSslConnectionFactory url)
+    (.createQueueConnection))))
 
 (defn create-session
   "Create a transacted JMS session on CONNECTION."
@@ -41,7 +41,7 @@
               consumer (.createConsumer session (.createQueue session queue))]
     (.start connection)
     (log/infof "Consumer %s: attempting to consume message."
-      (.getConsumerId consumer))
+               (.getConsumerId consumer))
     (.receive consumer)))
 
 (defn peek-message
@@ -86,15 +86,15 @@
               (log/infof "Task complete, consumed message %s" counter)
               (if (not (misc/message-ids-equal? peeked consumed))
                 (log/warnf
-                  (str/join \space ["Messages differ:"
-                                    (with-out-str (pprint (data/diff peeked consumed)))])))
+                 (str/join \space ["Messages differ:"
+                                   (with-out-str (pprint (data/diff peeked consumed)))])))
               (recur (inc counter)))
             (do
               (log/errorf
-                (str/join
-                  \space ["Task returned nil/false,"
-                          "not consuming message %s and instead exiting"])
-                counter)
+               (str/join
+                \space ["Task returned nil/false,"
+                        "not consuming message %s and instead exiting"])
+               counter)
               peeked))))
       (recur counter))))
 

--- a/src/ptc/start.clj
+++ b/src/ptc/start.clj
@@ -1,31 +1,35 @@
 (ns ptc.start
   (:gen-class)
-  (:require [clojure.data          :as data]
-            [clojure.pprint        :refer [pprint]]
-            [clojure.string        :as str]
+  (:require [clojure.data :as data]
+            [clojure.pprint :refer [pprint]]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
-            [ptc.ptc               :as ptc]
-            [ptc.util.jms          :as jms]
-            [ptc.util.misc         :as misc])
-  (:import [javax.jms TextMessage DeliveryMode Session JMSException]
+            [ptc.ptc :as ptc]
+            [ptc.util.jms :as jms]
+            [ptc.util.misc :as misc])
+  (:import [javax.jms TextMessage DeliveryMode Session]
            [org.apache.activemq ActiveMQSslConnectionFactory]))
 
-(defn with-push-to-cloud-jms-connection
-  "Call (use connection queue) for the JMS queue in ENVIRONMENT."
-  [environment use]
-  (let [path (format "secret/dsde/gotc/%s/activemq/logins/zamboni" environment)
-        {:keys [url username password queue]} (misc/vault-secrets path)
-        factory (new ActiveMQSslConnectionFactory url)]
-    (with-open [connection (.createQueueConnection factory username password)]
-      (use connection queue))))
+(defn create-queue-connection
+  "Create a javax.jms.QueueConnection to an ActiveMQ server"
+  ([url username password]
+   (->
+     (new ActiveMQSslConnectionFactory url)
+     (.createQueueConnection username password)))
+  ([url]
+   (->
+     (new ActiveMQSslConnectionFactory url)
+     (.createQueueConnection))))
 
 (defn create-session
-  "Open a JMS session on CONNECTION, conditionally TRANSACTED?"
-  [connection transacted?]
-  (.createSession connection transacted?
-                  (if transacted?
-                    Session/SESSION_TRANSACTED
-                    Session/AUTO_ACKNOWLEDGE)))
+  "Create a transacted JMS session on CONNECTION."
+  [connection]
+  (.createSession connection false Session/AUTO_ACKNOWLEDGE))
+
+(defn create-session-transacted
+  "Create a transacted JMS session on CONNECTION."
+  [connection]
+  (.createSession connection true Session/SESSION_TRANSACTED))
 
 ;; We are using sync receipt for now
 ;; https://activemq.apache.org/maven/apidocs/org/apache/activemq/ActiveMQMessageConsumer.html
@@ -33,90 +37,84 @@
 (defn consume
   "The text from a message from JMS QUEUE through CONNECTION."
   [connection queue]
-  (with-open [session (create-session connection false)]
-    (let [queue (.createQueue session queue)]
-      (with-open [consumer (.createConsumer session queue)]
-        (.start connection)
-        (log/infof
-         "Consumer %s: attempting to consume message."
-         (.getConsumerId consumer))
-        (.receive consumer)))))
+  (with-open [session  (create-session connection)
+              consumer (.createConsumer session (.createQueue session queue))]
+    (.start connection)
+    (log/infof "Consumer %s: attempting to consume message."
+      (.getConsumerId consumer))
+    (.receive consumer)))
 
 (defn peek-message
   "Peek 1 message from JMS QUEUE through CONNECTION."
   [connection queue]
-  (with-open [session (create-session connection false)]
-    (let [queue (.createQueue session queue)]
-      (with-open [browser (.createBrowser session queue)]
-        (.start connection)
-        (log/debugf "Browser: attempting to peek message.")
-        (let [msg-enum (.getEnumeration browser)]
-          (when (not (.hasMoreElements msg-enum))
-            (Thread/sleep 10000))
-          (.nextElement msg-enum))))))
+  (with-open [session (create-session connection)
+              browser (.createBrowser session (.createQueue session queue))]
+    (.start connection)
+    (log/debugf "Browser: attempting to peek message.")
+    (let [msg-enum (.getEnumeration browser)]
+      (when (not (.hasMoreElements msg-enum))
+        (Thread/sleep 10000))
+      (.nextElement msg-enum))))
 
 (defn produce
   "Enqueue the TEXT with PROPERTIES map to JMS QUEUE through CONNECTION."
   [connection queue text properties]
   (letfn [(add-property [^TextMessage message k v]
-            (.setStringProperty message (name k) v))
-          (send [connection queue]
-            (with-open [session (create-session connection true)]
-              (let [queue (.createQueue session queue)
-                    message (.createTextMessage session text)]
-                (doseq [[k v] properties]
-                  (add-property message k v))
-                (with-open [producer (.createProducer session queue)]
-                  (.setDeliveryMode producer DeliveryMode/PERSISTENT)
-                  (.start connection)
-                  (.send producer message)
-                  (.commit session)))))]
-    (send connection queue)))
+            (.setStringProperty message (name k) v))]
+    (with-open [session (create-session-transacted connection)]
+      (let [queue   (.createQueue session queue)
+            message (.createTextMessage session text)]
+        (doseq [[k v] properties] (add-property message k v))
+        (with-open [producer (.createProducer session queue)]
+          (.setDeliveryMode producer DeliveryMode/PERSISTENT)
+          (.start connection)
+          (.send producer message)
+          (.commit session))))))
 
 (defn listen-and-consume-from-queue
   "Listen to QUEUE on CONNECTION for messages,
   and call (TASK! message) until it is false."
-  ([task! connection queue]
-   (loop [counter 0]
-     (if-let [peeked (peek-message connection queue)]
-       ; to avoid NPE on ednify
-       (let [peeked (jms/ednify peeked)]
-         (do (log/infof "Peeked message %s: %s" counter peeked)
-             (if (task! peeked)
-               (let [consumed (jms/ednify (consume connection queue))]
-                 (log/infof "Task complete, consumed message %s" counter)
-                 (if (not (misc/message-ids-equal? peeked consumed))
-                   (log/warnf
-                    (str/join \space ["Messages differ:"
-                                      (with-out-str (pprint (data/diff peeked consumed)))])))
-                 (recur (inc counter)))
-               (do
-                 (log/errorf
-                  (str/join
-                   \space ["Task returned nil/false,"
-                           "not consuming message %s and instead exiting"])
-                  counter)
-                 peeked))))
-       (recur counter))))
-  ([connection queue]
-   (let [ptc-bucket-name (or (System/getenv "PTC_BUCKET_NAME") "broad-gotc-dev-zero-test")
-         push-to (misc/gs-url ptc-bucket-name)
-         upload-sample! (fn [msg] (jms/handle-message push-to msg))]
-     (listen-and-consume-from-queue upload-sample! connection queue))))
+  [task! connection queue]
+  (loop [counter 0]
+    (if-let [peeked (peek-message connection queue)]
+      ; to avoid NPE on ednify
+      (let [peeked (jms/ednify peeked)]
+        (do
+          (log/infof "Peeked message %s: %s" counter peeked)
+          (if (task! peeked)
+            (let [consumed (jms/ednify (consume connection queue))]
+              (log/infof "Task complete, consumed message %s" counter)
+              (if (not (misc/message-ids-equal? peeked consumed))
+                (log/warnf
+                  (str/join \space ["Messages differ:"
+                                    (with-out-str (pprint (data/diff peeked consumed)))])))
+              (recur (inc counter)))
+            (do
+              (log/errorf
+                (str/join
+                  \space ["Task returned nil/false,"
+                          "not consuming message %s and instead exiting"])
+                counter)
+              peeked))))
+      (recur counter))))
 
-(defn message-loop
-  "Loop with a JMS connection in ENVIRONMENT."
-  [environment]
-  (while true
-    (try
-      (with-push-to-cloud-jms-connection
-        environment
-        listen-and-consume-from-queue)
-      (catch Throwable x
-        (log/error x "caught in message-loop")))))
+(defn- message-loop
+  "Loop and consume messages using the Zamboni ActiveMQ server."
+  []
+  (let [queue      (misc/getenv! "ZAMBONI_ACTIVEMQ_QUEUE_NAME")
+        url        (misc/getenv! "ZAMBONI_ACTIVEMQ_URL")
+        vault-path (misc/getenv! "ZAMBONI_ACTIVEMQ_SECRET_PATH")
+        bucket-url (misc/getenv! "PTC_BUCKET_URL")
+        {:keys [username password]} (misc/vault-secrets vault-path)]
+    (while true
+      (try
+        (with-open [connection (create-queue-connection url username password)]
+          (let [upload-sample! (partial jms/handle-message bucket-url)]
+            (listen-and-consume-from-queue upload-sample! connection queue)))
+        (catch Throwable x
+          (log/error x "caught in message-loop"))))))
 
 (defn -main
   []
-  (let [environment (or (System/getenv "ENVIRONMENT") "dev")]
-    (log/infof "%s starting up on %s" ptc/the-name environment)
-    (message-loop environment)))
+  (log/infof "%s starting up" ptc/the-name)
+  (message-loop))

--- a/src/ptc/util/misc.clj
+++ b/src/ptc/util/misc.clj
@@ -80,12 +80,6 @@
                                  ptc/the-name exit args err))))
     (str/trim out)))
 
-(defn get-auth-header!
-  "Return an Authorization header with a Bearer token."
-  []
-  {"Authorization"
-   (str "Bearer" \space (shell! "gcloud" "auth" "print-access-token"))})
-
 (defn slurp-json
   "Nil or the JSON in FILE."
   [file]
@@ -122,3 +116,11 @@
   [& messages]
   (or (empty? messages)
       (apply = (map :properties messages))))
+
+(defn getenv!
+  "Get value of environment variable NAME or throw if nil."
+  [name]
+  (let [value (System/getenv name)]
+    (when (nil? value)
+      (throw (IllegalStateException. (str name " must not be nil"))))
+    value))

--- a/src/ptc/util/misc.clj
+++ b/src/ptc/util/misc.clj
@@ -91,21 +91,6 @@
   "The nil UUID."
   (UUID/fromString "00000000-0000-0000-0000-000000000000"))
 
-(defn gs-url
-  "Format BUCKET and OBJECT into a gs://bucket/object URL."
-  ([bucket object]
-   (when-not (and (string?        bucket)
-                  (seq            bucket)
-                  (not-any? #{\/} bucket))
-     (let [fmt "The bucket (%s) must be a non-empty string."
-           msg (format fmt bucket)]
-       (throw (IllegalArgumentException. msg))))
-   (if (nil? object)
-     (str "gs://" bucket)
-     (str "gs://" bucket "/" object)))
-  ([bucket]
-   (gs-url bucket nil)))
-
 (defn parse-json-string
   "Parse the json string STR into a keyword-string map"
   [str]

--- a/test/ptc/acl/permission_test.clj
+++ b/test/ptc/acl/permission_test.clj
@@ -30,11 +30,11 @@
   "Generate auth header from the ACL test user service account."
   []
   (let [token (some-> test-user misc/vault-secrets (:value) .getBytes
-                io/input-stream GoogleCredentials/fromStream
-                (.createScoped ["https://www.googleapis.com/auth/cloud-platform"
-                                "https://www.googleapis.com/auth/userinfo.email"
-                                "https://www.googleapis.com/auth/userinfo.profile"])
-                .refreshAccessToken .getTokenValue)]
+                      io/input-stream GoogleCredentials/fromStream
+                      (.createScoped ["https://www.googleapis.com/auth/cloud-platform"
+                                      "https://www.googleapis.com/auth/userinfo.email"
+                                      "https://www.googleapis.com/auth/userinfo.profile"])
+                      .refreshAccessToken .getTokenValue)]
     {"Authorization" (str/join \space ["Bearer" token])}))
 
 (deftest bucket-permission-test
@@ -44,36 +44,36 @@
         (hash (gcs/list-objects aou-in-bucket))
         (catch Exception e
           (is (= 403 (:status (ex-data e)))
-            "The user is able to list the input bucket!!")))
+              "The user is able to list the input bucket!!")))
       (try
         (hash (gcs/list-objects aou-out-bucket))
         (catch Exception e
           (is (= 403 (:status (ex-data e)))
-            "The user is able to list the output bucket!!")))))
+              "The user is able to list the output bucket!!")))))
   (testing "Unauthorized user cannot upload object to the PTC buckets."
     (with-redefs [gcs/get-auth-header! get-test-user-header]
       (try
         (hash (gcs/upload-file "deps.edn" aou-in-bucket "deps.edn"))
         (catch Exception e
           (is (= 403 (:status (ex-data e)))
-            "The user is able to upload object to the input bucket!!")))
+              "The user is able to upload object to the input bucket!!")))
       (try
         (hash (gcs/upload-file "deps.edn" aou-out-bucket "deps.edn"))
         (catch Exception e
           (is (= 403 (:status (ex-data e)))
-            "The user is able to upload object to the output bucket!!")))))
+              "The user is able to upload object to the output bucket!!")))))
   (testing "Unauthorized user cannot delete object from the PTC buckets."
     (with-redefs [gcs/get-auth-header! get-test-user-header]
       (try
         (hash (gcs/delete-object aou-in-bucket "deps.edn"))
         (catch Exception e
           (is (contains? #{403 404} (:status (ex-data e)))
-            "The user is able to delete object from the input bucket!!")))
+              "The user is able to delete object from the input bucket!!")))
       (try
         (hash (gcs/delete-object aou-out-bucket "deps.edn"))
         (catch Exception e
           (is (contains? #{403 404} (:status (ex-data e)))
-            "The user is able to delete object from the output bucket!!"))))))
+              "The user is able to delete object from the output bucket!!"))))))
 
 (deftest workflow-permission-test
   (testing "Unauthorized users cannot query for workflows in the AoU Cromwell."
@@ -82,11 +82,11 @@
         (hash (cromwell/query aou-cromwell misc/uuid-nil)))
       (catch Exception e
         (is (= 401 (:status (ex-data e)))
-          "The user is able to query for a workflow!!"))))
+            "The user is able to query for a workflow!!"))))
   (testing "Unauthorized users cannot get statuses of workflows in the AoU Cromwell."
     (try
       (with-redefs [gcs/get-auth-header! get-test-user-header]
         (hash (cromwell/status aou-cromwell misc/uuid-nil)))
       (catch Exception e
         (is (= 401 (:status (ex-data e)))
-          "The user is able to get status of a workflow!!")))))
+            "The user is able to get status of a workflow!!")))))

--- a/test/ptc/acl/permission_test.clj
+++ b/test/ptc/acl/permission_test.clj
@@ -1,11 +1,11 @@
 (ns ptc.acl.permission-test
   "Test that the right permissions are granted for AoU project."
-  (:require [ptc.tools.gcs  :as gcs]
-            [ptc.tools.cromwell  :as cromwell]
-            [ptc.util.misc     :as misc]
-            [clojure.string      :as str]
-            [clojure.java.io   :as io]
-            [clojure.test  :refer [deftest is testing]])
+  (:require [ptc.tools.gcs :as gcs]
+            [ptc.tools.cromwell :as cromwell]
+            [ptc.util.misc :as misc]
+            [clojure.string :as str]
+            [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]])
   (:import [com.google.auth.oauth2 GoogleCredentials]))
 
 (def aou-in-bucket
@@ -30,63 +30,63 @@
   "Generate auth header from the ACL test user service account."
   []
   (let [token (some-> test-user misc/vault-secrets (:value) .getBytes
-                      io/input-stream GoogleCredentials/fromStream
-                      (.createScoped ["https://www.googleapis.com/auth/cloud-platform"
-                                      "https://www.googleapis.com/auth/userinfo.email"
-                                      "https://www.googleapis.com/auth/userinfo.profile"])
-                      .refreshAccessToken .getTokenValue)]
+                io/input-stream GoogleCredentials/fromStream
+                (.createScoped ["https://www.googleapis.com/auth/cloud-platform"
+                                "https://www.googleapis.com/auth/userinfo.email"
+                                "https://www.googleapis.com/auth/userinfo.profile"])
+                .refreshAccessToken .getTokenValue)]
     {"Authorization" (str/join \space ["Bearer" token])}))
 
 (deftest bucket-permission-test
   (testing "Unauthorized user cannot list the PTC buckets."
-    (with-redefs [misc/get-auth-header! get-test-user-header]
+    (with-redefs [gcs/get-auth-header! get-test-user-header]
       (try
         (hash (gcs/list-objects aou-in-bucket))
         (catch Exception e
           (is (= 403 (:status (ex-data e)))
-              "The user is able to list the input bucket!!")))
+            "The user is able to list the input bucket!!")))
       (try
         (hash (gcs/list-objects aou-out-bucket))
         (catch Exception e
           (is (= 403 (:status (ex-data e)))
-              "The user is able to list the output bucket!!")))))
+            "The user is able to list the output bucket!!")))))
   (testing "Unauthorized user cannot upload object to the PTC buckets."
-    (with-redefs [misc/get-auth-header! get-test-user-header]
+    (with-redefs [gcs/get-auth-header! get-test-user-header]
       (try
         (hash (gcs/upload-file "deps.edn" aou-in-bucket "deps.edn"))
         (catch Exception e
           (is (= 403 (:status (ex-data e)))
-              "The user is able to upload object to the input bucket!!")))
+            "The user is able to upload object to the input bucket!!")))
       (try
         (hash (gcs/upload-file "deps.edn" aou-out-bucket "deps.edn"))
         (catch Exception e
           (is (= 403 (:status (ex-data e)))
-              "The user is able to upload object to the output bucket!!")))))
+            "The user is able to upload object to the output bucket!!")))))
   (testing "Unauthorized user cannot delete object from the PTC buckets."
-    (with-redefs [misc/get-auth-header! get-test-user-header]
+    (with-redefs [gcs/get-auth-header! get-test-user-header]
       (try
         (hash (gcs/delete-object aou-in-bucket "deps.edn"))
         (catch Exception e
           (is (contains? #{403 404} (:status (ex-data e)))
-              "The user is able to delete object from the input bucket!!")))
+            "The user is able to delete object from the input bucket!!")))
       (try
         (hash (gcs/delete-object aou-out-bucket "deps.edn"))
         (catch Exception e
           (is (contains? #{403 404} (:status (ex-data e)))
-              "The user is able to delete object from the output bucket!!"))))))
+            "The user is able to delete object from the output bucket!!"))))))
 
 (deftest workflow-permission-test
   (testing "Unauthorized users cannot query for workflows in the AoU Cromwell."
     (try
-      (with-redefs [misc/get-auth-header! get-test-user-header]
+      (with-redefs [gcs/get-auth-header! get-test-user-header]
         (hash (cromwell/query aou-cromwell misc/uuid-nil)))
       (catch Exception e
         (is (= 401 (:status (ex-data e)))
-            "The user is able to query for a workflow!!"))))
+          "The user is able to query for a workflow!!"))))
   (testing "Unauthorized users cannot get statuses of workflows in the AoU Cromwell."
     (try
-      (with-redefs [misc/get-auth-header! get-test-user-header]
+      (with-redefs [gcs/get-auth-header! get-test-user-header]
         (hash (cromwell/status aou-cromwell misc/uuid-nil)))
       (catch Exception e
         (is (= 401 (:status (ex-data e)))
-            "The user is able to get status of a workflow!!")))))
+          "The user is able to get status of a workflow!!")))))

--- a/test/ptc/integration/integration_test.clj
+++ b/test/ptc/integration/integration_test.clj
@@ -1,36 +1,19 @@
 (ns ptc.integration.integration-test
-  (:require [clojure.test  :refer [deftest is testing]]
-            [clojure.edn   :as edn]
-            [ptc.start     :as start]
-            [ptc.tools.gcs  :as gcs]
-            [ptc.util.misc  :as misc]
-            [ptc.util.jms  :as jms])
-  (:import [org.apache.activemq ActiveMQSslConnectionFactory]
-           (java.util UUID)))
+  (:require [clojure.test :refer [deftest is testing]]
+            [ptc.start :as start]
+            [ptc.tools.gcs :as gcs]
+            [ptc.util.jms :as jms]
+            [ptc.tools.jms :refer [with-test-queue-connection message]])
+  (:import (java.util UUID)))
 
-;; Local testing for ActiveMQ
-;; https://activemq.apache.org/how-do-i-embed-a-broker-inside-a-connection
-;;
-(defn with-test-jms-connection
-  "CALL with a local JMS connection for testing."
-  [call]
-  (let [url     "vm://localhost?broker.persistent=false"
-        factory (new ActiveMQSslConnectionFactory url)
-        queue   "test.queue"]
-    (with-open [connection (.createQueueConnection factory)]
-      (call connection queue))))
-
-(def message
-  "Example JMS message for testing."
-  (edn/read-string (slurp "test/data/good-jms.edn")))
 
 (def bucket
   "Storage bucket for running ptc.integration test with."
   "broad-gotc-dev-zero-test")
 
 (deftest integration
-  (let [prefix (str "test/" (UUID/randomUUID))
-        properties (::jms/Properties (jms/encode message))]
+  (let [prefix     (str "test/" (UUID/randomUUID))
+        properties (::jms/Properties (jms/encode @message))]
     (letfn [(task [_]
               (try
                 (testing "end-to-end: "
@@ -45,14 +28,14 @@
               (start/produce connection queue "text" properties)
               (start/listen-and-consume-from-queue task connection queue))]
       (testing "Message is not nil and can be properly read"
-        (if-let [msg (with-test-jms-connection flow)]
-          (is (= message (select-keys msg [::jms/Properties])))
+        (if-let [msg (with-test-queue-connection flow)]
+          (is (= @message (select-keys msg [::jms/Properties])))
           (is false))))))
 
 (deftest peeking
-  (let [properties (::jms/Properties (jms/encode message))]
+  (let [properties (::jms/Properties (jms/encode @message))]
     (letfn [(task [message] (is message) false)]
-      (with-test-jms-connection
+      (with-test-queue-connection
         (fn [connection queue]
           (testing "Message given to task isn't nil"
             (start/produce connection queue "text" properties)
@@ -60,4 +43,4 @@
           (testing "The message was only peeked and can still be consumed"
             (let [msg (jms/ednify (start/consume connection queue))]
               (testing "Message is not nil and can be properly read"
-                (is (= message (select-keys msg [::jms/Properties])))))))))))
+                (is (= @message (select-keys msg [::jms/Properties])))))))))))

--- a/test/ptc/integration/integration_test.clj
+++ b/test/ptc/integration/integration_test.clj
@@ -6,7 +6,6 @@
             [ptc.tools.jms :refer [with-test-queue-connection message]])
   (:import (java.util UUID)))
 
-
 (def bucket
   "Storage bucket for running ptc.integration test with."
   "broad-gotc-dev-zero-test")

--- a/test/ptc/integration/jms_test.clj
+++ b/test/ptc/integration/jms_test.clj
@@ -1,17 +1,17 @@
 (ns ptc.integration.jms-test
-  (:require [clojure.data      :as data]
+  (:require [clojure.data :as data]
             [clojure.data.json :as json]
-            [clojure.edn       :as edn]
-            [clojure.java.io   :as io]
-            [clojure.set       :as set]
-            [clojure.string    :as str]
-            [clojure.test      :refer [deftest is testing]]
-            [ptc.start         :as start]
-            [ptc.tools.gcs      :as gcs]
-            [ptc.util.jms      :as jms]
-            [ptc.util.misc     :as misc])
-  (:import [java.util UUID]
-           [org.apache.activemq ActiveMQSslConnectionFactory]))
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.set :as set]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [ptc.start :as start]
+            [ptc.tools.gcs :as gcs]
+            [ptc.util.jms :as jms]
+            [ptc.util.misc :as misc]
+            [ptc.tools.jms :as testtools])
+  (:import [java.util UUID]))
 
 (def gcs-test-bucket
   "Throw test files in this bucket."
@@ -37,18 +37,6 @@
          (->>
           (gcs/list-objects gcs-test-bucket name#)
           (run! (comp (partial gcs/delete-object gcs-test-bucket) :name)))))))
-
-;; Local testing for ActiveMQ
-;; https://activemq.apache.org/how-do-i-embed-a-broker-inside-a-connection
-;;
-(defn with-test-jms-connection
-  "CALL with a local JMS connection for testing."
-  [call]
-  (let [url     "vm://localhost?broker.persistent=false"
-        factory (new ActiveMQSslConnectionFactory url)
-        queue   "test.queue"]
-    (with-open [connection (.createQueueConnection factory)]
-      (call connection queue))))
 
 (defn list-gcs-folder
   "Nil or URLs for the GCS objects of folder."
@@ -99,7 +87,7 @@
                      re-pattern)
         workflow (get-in good path)]
     (with-temporary-gcs-folder folder
-      (with-test-jms-connection
+      (testtools/with-test-queue-connection
         (fn [connection queue]
           (testing "a BAD message"
             (start/produce connection queue
@@ -137,7 +125,7 @@
                           (assoc-in where n)
                           jms/encode
                           ::jms/Properties))]
-      (start/with-push-to-cloud-jms-connection "dev"
+      (testtools/with-dev-queue-connection
         (fn [connection queue]
           (run! (partial start/produce connection queue blame)
                 (map make (range 1 (inc n)))))))))

--- a/test/ptc/tools/cromwell.clj
+++ b/test/ptc/tools/cromwell.clj
@@ -1,26 +1,25 @@
 (ns ptc.tools.cromwell
   "Utility functions for Cromwell."
-  (:require [clojure.data.json :as json]
-            [clj-http.client :as client]
-            [clojure.tools.logging :as log]
-            [ptc.util.misc     :as misc]))
+  (:require [clj-http.client :as client]
+            [ptc.util.misc :as misc]
+            [ptc.tools.gcs :as gcs]))
 
 (defn status
   "Status of the workflow with ID at CROMWELL-URL."
   [cromwell-url id]
-  (let [auth-header (misc/get-auth-header!)
-        response (client/get (str cromwell-url "/api/workflows/v1/" id "/status")
-                             {:headers auth-header})]
+  (let [auth-header (gcs/get-auth-header!)
+        response    (client/get (str cromwell-url "/api/workflows/v1/" id "/status")
+                      {:headers auth-header})]
     (->> (:body response)
-         (misc/parse-json-string)
-         (:status))))
+      (misc/parse-json-string)
+      (:status))))
 
 (defn query
   "Query for a workflow with ID at CROMWELL-URL."
   [cromwell-url id]
-  (let [auth-header (misc/get-auth-header!)
-        response (client/get (str cromwell-url "/api/workflows/v1/" id "/query")
-                             {:headers auth-header})]
+  (let [auth-header (gcs/get-auth-header!)
+        response    (client/get (str cromwell-url "/api/workflows/v1/" id "/query")
+                      {:headers auth-header})]
     (->> (:body response)
-         (misc/parse-json-string)
-         (:results))))
+      (misc/parse-json-string)
+      (:results))))

--- a/test/ptc/tools/cromwell.clj
+++ b/test/ptc/tools/cromwell.clj
@@ -9,17 +9,17 @@
   [cromwell-url id]
   (let [auth-header (gcs/get-auth-header!)
         response    (client/get (str cromwell-url "/api/workflows/v1/" id "/status")
-                      {:headers auth-header})]
+                                {:headers auth-header})]
     (->> (:body response)
-      (misc/parse-json-string)
-      (:status))))
+         (misc/parse-json-string)
+         (:status))))
 
 (defn query
   "Query for a workflow with ID at CROMWELL-URL."
   [cromwell-url id]
   (let [auth-header (gcs/get-auth-header!)
         response    (client/get (str cromwell-url "/api/workflows/v1/" id "/query")
-                      {:headers auth-header})]
+                                {:headers auth-header})]
     (->> (:body response)
-      (misc/parse-json-string)
-      (:results))))
+         (misc/parse-json-string)
+         (:results))))

--- a/test/ptc/tools/gcs.clj
+++ b/test/ptc/tools/gcs.clj
@@ -41,6 +41,12 @@
       (throw (IllegalArgumentException. (format "Bad GCS URL: '%s'" url))))
     [bucket (or object "")]))
 
+(defn get-auth-header!
+  "Return an Authorization header with a Bearer token."
+  []
+  {"Authorization"
+   (str "Bearer" \space (misc/shell! "gcloud" "auth" "print-access-token"))})
+
 (defn list-objects
   "The objects in BUCKET with PREFIX in a lazy sequence."
   ([bucket prefix]
@@ -49,7 +55,7 @@
                    (-> {:method       :get   ;; :debug true :debug-body true
                         :url          (str bucket-url bucket "/o")
                         :content-type :application/json
-                        :headers      (misc/get-auth-header!)
+                        :headers      (get-auth-header!)
                         :query-params {:prefix prefix
                                        :maxResults 999
                                        :pageToken pageToken}}
@@ -68,7 +74,7 @@
                   :url     (bucket-object-url bucket object)
                   :headers headers}))
   ([bucket object]
-   (delete-object bucket object (misc/get-auth-header!)))
+   (delete-object bucket object (get-auth-header!)))
   ([url]
    (apply delete-object (parse-gs-url url))))
 
@@ -87,6 +93,6 @@
          :body
          (json/read-str :key-fn keyword))))
   ([file bucket object]
-   (upload-file file bucket object (misc/get-auth-header!)))
+   (upload-file file bucket object (get-auth-header!)))
   ([file url]
    (apply upload-file file (parse-gs-url url))))

--- a/test/ptc/tools/jms.clj
+++ b/test/ptc/tools/jms.clj
@@ -1,0 +1,28 @@
+(ns ptc.tools.jms
+  (:require [clojure.edn :as edn]
+            [ptc.start :as start]
+            [ptc.util.misc :as misc]))
+
+;; Local testing for ActiveMQ
+;; https://activemq.apache.org/how-do-i-embed-a-broker-inside-a-connection
+(defn with-test-queue-connection
+  "CALL with a local JMS connection for testing."
+  [closure]
+  (let [url "vm://localhost?broker.persistent=false"
+        test-queue-name "test.queue"]
+    (with-open [connection (start/create-queue-connection url)]
+      (closure connection test-queue-name))))
+
+(defn with-dev-queue-connection
+  "CALL with the dev JMS connection for testing."
+  [closure]
+  (let [url            "failover:ssl://vpicard-jms-dev.broadinstitute.org:61616"
+        dev-queue-name "wfl.broad.pushtocloud.enqueue.dev"
+        vault-path     "secret/dsde/gotc/dev/activemq/logins/zamboni"
+        {:keys [username password]} (misc/vault-secrets vault-path)]
+    (with-open [connection (start/create-queue-connection url username password)]
+      (closure connection dev-queue-name))))
+
+(def message
+  "Example JMS message for testing."
+  (delay (edn/read-string (slurp "test/data/good-jms.edn"))))

--- a/test/ptc/unit/start_test.clj
+++ b/test/ptc/unit/start_test.clj
@@ -1,46 +1,29 @@
 (ns ptc.unit.start-test
   (:require [clojure.test :refer [deftest is testing]]
-            [clojure.edn  :as edn]
-            [ptc.start    :as start]
-            [ptc.util.jms :as jms])
-  (:import [org.apache.activemq ActiveMQSslConnectionFactory]))
-
-;; Local testing for ActiveMQ
-;; https://activemq.apache.org/how-do-i-embed-a-broker-inside-a-connection
-;;
-(defn with-test-jms-connection
-  "CALL with a local JMS connection for testing."
-  [call]
-  (let [url     "vm://localhost?broker.persistent=false"
-        factory (new ActiveMQSslConnectionFactory url)
-        queue   "test.queue"]
-    (with-open [connection (.createQueueConnection factory)]
-      (call connection queue))))
-
-(def message
-  "Example JMS message for testing."
-  (edn/read-string (slurp "test/data/good-jms.edn")))
+            [ptc.start :as start]
+            [ptc.util.jms :as jms]
+            [ptc.tools.jms :refer [with-test-queue-connection message]]))
 
 (deftest produce-consume-message
-  (let [text "consume"
-        properties (::jms/Properties (jms/encode message))]
+  (let [text       "consume"
+        properties (::jms/Properties (jms/encode @message))]
     (letfn [(produce-consume [connection queue]
               (start/produce connection queue text properties)
               (start/consume connection queue))]
-      (if-let [msg (with-test-jms-connection produce-consume)]
+      (if-let [msg (with-test-queue-connection produce-consume)]
         (testing "Message is not nil and can be properly consumed"
           (is (= text (.getText msg)))
-          (is (apply = (map ::jms/Properties [message (jms/ednify msg)]))))
+          (is (apply = (map ::jms/Properties [@message (jms/ednify msg)]))))
         (is false)))))
 
 (deftest produce-peek-message
-  (let [text "peek"
-        properties (::jms/Properties (jms/encode message))]
+  (let [text       "peek"
+        properties (::jms/Properties (jms/encode @message))]
     (letfn [(produce-peek [connection queue]
               (start/produce connection queue text properties)
               (start/peek-message connection queue))]
-      (if-let [msg (with-test-jms-connection produce-peek)]
+      (if-let [msg (with-test-queue-connection produce-peek)]
         (testing "Message is not nil and can be properly consumed"
           (is (= text (.getText msg)))
-          (is (apply = (map ::jms/Properties [message (jms/ednify msg)]))))
+          (is (apply = (map ::jms/Properties [@message (jms/ednify msg)]))))
         (is false)))))


### PR DESCRIPTION
### Purpose
As suggested by Tom, we shouldn't use vault to store stuff that isn't secret.
In this PR, PTC no longer looks for the queue name and url in vault in favour of using the following environment variables (to be configured in `/etc/sysconfig/push-to-cloud`):
- `ZAMBONI_ACTIVEMQ_QUEUE_NAME`: The name of the queue to poll
- `ZAMBONI_ACTIVEMQ_URL`: The url of the ActiveMQ server
- `ZAMBONI_ACTIVEMQ_SECRET_PATH`: The vault path to the username/password secret. This was previously computed from the "environment". We don't need these in PTC.

These variables are changed and the vault is read once at start-up so that we don't get connection failures later on (previously it called `with-push-to-cloud-jms-connection` which did a `vault read` in the main loop).

There's also the `PTC_BUCKET_URL` variable I've used instead of `_NAME`. All environment variables are used together - this should make it easier for debugging and configuration as it'll fail in one place.

