### PR TITLE
[GH-893] restart policy: max 3 fails in 5 minutes in 1 minute intervals

### DIFF
--- a/in/unit/push-to-cloud.service.in
+++ b/in/unit/push-to-cloud.service.in
@@ -1,13 +1,14 @@
 [Unit]
 Description=All-of-Us Arrays Push-to-Cloud Daemon
 After=network.target
-StartLimitIntervalSec=0
+StartLimitIntervalSec=300
+StartLimitBust=3
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/push-to-cloud
 ExecStart=java -cp %PTC_BIN clojure.main -m ptc.start
 Restart=always
-RestartSec=1
+RestartSec=60
 SuccessExitStatus=143
 User=ptc
 


### PR DESCRIPTION
### Purpose
In this change, I'm setting a re-start policy for the `systemd` unit before a human has to manually start the service.

The unit will *always* restart unless it has failed 3 times within 5 minutes.
The unit will be restarted in 1 minute intervals.

I'm making this PR separate to the code changes as I'm applying them on-top of https://github.com/broadinstitute/push-to-cloud-service/pull/32.