### PR TITLE
[GH-891] Get Jenkins job working

### DIFF
--- a/src/ptc/util/misc.clj
+++ b/src/ptc/util/misc.clj
@@ -40,10 +40,11 @@
 (defn vault-secrets
   "Return the vault-secrets at PATH."
   [path]
-  (let [token-path (str (System/getProperty "user.home") "/.vault-token")]
+  (let [env-token  (System/getenv "VAULT_TOKEN")
+        token-path (str (System/getProperty "user.home") "/.vault-token")]
     (try (vault/read-secret
           (doto (vault/new-client "https://clotho.broadinstitute.org:8200/")
-            (vault/authenticate! :token (slurp token-path)))
+            (vault/authenticate! :token (or env-token (slurp token-path))))
           path)
          (catch Throwable e
            (log/warn e "Issue with Vault")

--- a/test/ptc/e2e/system_test.clj
+++ b/test/ptc/e2e/system_test.clj
@@ -9,7 +9,8 @@
             [ptc.tools.utils :as utils]
             [ptc.util.jms :as jms])
   (:import [java.lang Integer]
-           [java.util UUID]))
+           [java.util UUID]
+           [java.util.concurrent TimeUnit]))
 
 (def environment
   (or (System/getenv "ENVIRONMENT") "dev"))
@@ -51,6 +52,7 @@
       (let [params (str cloud-prefix "/params.txt")
             ptc (str cloud-prefix "/ptc.json")
             wait (timeout 180000 #(gcs/wait-for-files-in-bucket cloud-prefix [ptc]))
+            wait-after-upload (.sleep TimeUnit/SECONDS 3)
             {:keys [notifications] :as request} (gcs/gcs-edn ptc)
             pushed (utils/pushed-files (first notifications) params)
             gcs (timeout 180000 #(gcs/wait-for-files-in-bucket cloud-prefix pushed))]

--- a/test/ptc/e2e/system_test.clj
+++ b/test/ptc/e2e/system_test.clj
@@ -52,7 +52,8 @@
       (let [params (str cloud-prefix "/params.txt")
             ptc (str cloud-prefix "/ptc.json")
             wait (timeout 180000 #(gcs/wait-for-files-in-bucket cloud-prefix [ptc]))
-            wait-after-upload (.sleep TimeUnit/SECONDS 3)
+            ; Dodge rarely observed race condition where `cat` errors even though `ls` shows the file
+            wait-after-upload (.sleep TimeUnit/SECONDS 1)
             {:keys [notifications] :as request} (gcs/gcs-edn ptc)
             pushed (utils/pushed-files (first notifications) params)
             gcs (timeout 180000 #(gcs/wait-for-files-in-bucket cloud-prefix pushed))]


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-891

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- PTC will now use `VAULT_TOKEN` directly as a token if it is truthy, otherwise it will look for one in the home directory.
- I ran the test so many times I actually hit a weird race condition where `gsutil ls` would show ptc.json as present but `gsutil cat` called immediately after would fail and crash the test. The test now waits a second after `ls` sees the file before trying to `cat` it, this solved the issue for me.
  - https://gotc-jenkins.dsp-techops.broadinstitute.org/job/aou-ptc-wfl-end-to-end/16/console
  - https://gotc-jenkins.dsp-techops.broadinstitute.org/job/aou-ptc-wfl-end-to-end/15/console
  - https://gotc-jenkins.dsp-techops.broadinstitute.org/job/aou-ptc-wfl-end-to-end/14/console
  - In all three of the above I was able to `gsutil cat` the file with the _exact same service account being used in the Jenkins job_, so just waiting seems to be a reasonable fix

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Check out the passed Jenkins e2e test job: https://gotc-jenkins.dsp-techops.broadinstitute.org/job/aou-ptc-wfl-end-to-end/24/console
  - Demonstrates that it passes on Jenkins and that it picks up the Vault token out of the environment
- Run `clojure -A:test e2e` locally on my branch
  - Demonstrates I didn't screw up anything for non-Jenkins environments
