### PR TITLE
[GH-893] let ptc die - don't loop forever

### DIFF
--- a/src/ptc/start.clj
+++ b/src/ptc/start.clj
@@ -107,12 +107,12 @@
         bucket-url     (misc/getenv-or-throw "PTC_BUCKET_URL")
         upload-sample! (partial jms/handle-message bucket-url)
         {:keys [username password]} (misc/vault-secrets vault-path)]
-    (while true
       (try
         (with-open [connection (create-queue-connection url username password)]
           (listen-and-consume-from-queue upload-sample! connection queue))
         (catch Throwable x
-          (log/error x "caught in message-loop"))))))
+          (log/fatal x "Fatal error in message loop")
+          (System/exit 1)))))
 
 (defn -main
   []

--- a/src/ptc/start.clj
+++ b/src/ptc/start.clj
@@ -107,12 +107,12 @@
         bucket-url     (misc/getenv-or-throw "PTC_BUCKET_URL")
         upload-sample! (partial jms/handle-message bucket-url)
         {:keys [username password]} (misc/vault-secrets vault-path)]
-      (try
-        (with-open [connection (create-queue-connection url username password)]
-          (listen-and-consume-from-queue upload-sample! connection queue))
-        (catch Throwable x
-          (log/fatal x "Fatal error in message loop")
-          (System/exit 1)))))
+    (try
+      (with-open [connection (create-queue-connection url username password)]
+        (listen-and-consume-from-queue upload-sample! connection queue))
+      (catch Throwable x
+        (log/fatal x "Fatal error in message loop")
+        (System/exit 1)))))
 
 (defn -main
   []


### PR DESCRIPTION
### Purpose
As discussed, we need to make sure PTC doesn't keep trying to loop forever. This was as simple as removing a while true loop.
Now if the message loop throws, PTC will exit with a non-zero exit code.