### PR TITLE
[GH-862] fix production activemq server url

### DIFF
--- a/test/ptc/tools/jms.clj
+++ b/test/ptc/tools/jms.clj
@@ -18,7 +18,7 @@
 (defn with-queue-connection
   "CALL with the ENV JMS connection for testing."
   [env closure]
-  (let [config {:prod {:url        "failover:ssl://vpicard-jms-prod.broadinstitute.org:61616"
+  (let [config {:prod {:url        "failover:ssl://vpicard-jms.broadinstitute.org:61616"
                        :queue      "wfl.broad.pushtocloud.enqueue.prod"
                        :vault-path "secret/dsde/gotc/prod/activemq/logins/zamboni"}
                 :dev  {:url        "failover:ssl://vpicard-jms-dev.broadinstitute.org:61616"


### PR DESCRIPTION
### Purpose
The url for the production ActiveMQ server was incorrect in vault. I used that value in my previous PRs.
This PR fixes it for the tests. I've already configured the production environment.