### PR TITLE
[GH-900] Update queue alias test message

### DIFF
--- a/test/ptc/tools/jms.clj
+++ b/test/ptc/tools/jms.clj
@@ -66,7 +66,7 @@
         env              (edn/read-string (second args))
         analysis-version (rand-int Integer/MAX_VALUE)
         where            [::jms/Properties :payload :workflow :analysisCloudVersion]
-        jms-message      (fix-paths "./test/data/good-jms.edn")
+        jms-message      (edn/read-string (slurp "./test/data/plumbing-test-jms-dev.edn"))
         message          (assoc-in jms-message where analysis-version)]
     (when-not (pos-int? n)
       (throw (IllegalArgumentException. "Must specify a positive integer")))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

Addresses ticket https://broadinstitute.atlassian.net/browse/GH-900

### Changes
Use a test message that references on-prem data so that PTC does not hang/crash when trying to copy the files.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Note: If you queue multiple messages at the same time (e.g. `clojure -A:queue 3 "dev"`), they will all be identical. I didn't change it because I don't think queuing multiple messages at the same time is currently required by any of our testing.