### PR TITLE
Recur based on exceptions rather than string parsing

### DIFF
--- a/test/ptc/e2e/system_test.clj
+++ b/test/ptc/e2e/system_test.clj
@@ -49,14 +49,14 @@
         cloud-prefix     (jms/cloud-prefix bucket workflow)]
     (jms-tools/queue-messages 1 environment message)
     (testing "Files are uploaded to the input bucket"
-      (let [params   (str cloud-prefix "/params.txt")
-            ptc      (str cloud-prefix "/ptc.json")
-            ptc-json (timeout 360000 #(gcs/wait-for-files-in-bucket [ptc]))]
-        (is (not= ptc-json ::timed-out) "Timed out waiting for ptc.json to upload")
-        (let [{:keys [notifications]} (gcs/gcs-edn ptc)
-              pushed                  (utils/pushed-files (first notifications) params)
-              pushes-files            (timeout 180000 #(gcs/wait-for-files-in-bucket pushed))]
-          (is (not= pushes-files ::timed-out) "Timed out waiting for expected files to upload")
+      (let [params      (str cloud-prefix "/params.txt")
+            ptc-file    (str cloud-prefix "/ptc.json")
+            ptc-present (timeout 360000 #(gcs/wait-for-files-in-bucket [ptc-file]))]
+        (is (not= ptc-present ::timed-out) "Timed out waiting for ptc.json to upload")
+        (let [{:keys [notifications]} (gcs/gcs-edn ptc-file)
+              expected-files          (utils/pushed-files (first notifications) params)
+              expected-present        (timeout 180000 #(gcs/wait-for-files-in-bucket expected-files))]
+          (is (not= expected-present ::timed-out) "Timed out waiting for expected files to upload")
           (is (= (jms/jms->params workflow) (gcs/gcs-cat params))))))
     (testing "Cromwell workflow is started by WFL"
       (let [workflow-id (timeout 180000 #(wfl/wait-for-workflow-creation wfl-url chipwell-barcode analysis-version))]

--- a/test/ptc/e2e/system_test.clj
+++ b/test/ptc/e2e/system_test.clj
@@ -51,12 +51,10 @@
     (testing "Files are uploaded to the input bucket"
       (let [params (str cloud-prefix "/params.txt")
             ptc    (str cloud-prefix "/ptc.json")
-            _      (timeout 360000 #(gcs/wait-for-files-in-bucket cloud-prefix [ptc]))
-            ; Dodge rarely observed race condition where `cat` errors even though `ls` shows the file
-            _      (.sleep TimeUnit/SECONDS 1)
+            _      (timeout 360000 #(gcs/wait-for-files-in-bucket [ptc]))
             {:keys [notifications]} (gcs/gcs-edn ptc)
             pushed (utils/pushed-files (first notifications) params)
-            gcs    (timeout 180000 #(gcs/wait-for-files-in-bucket cloud-prefix pushed))]
+            gcs    (timeout 180000 #(gcs/wait-for-files-in-bucket pushed))]
         (is (not= gcs ::timed-out) "Timeout waiting for files to upload")
         (let [diff (set/difference (set gcs) (set pushed))]
           (is (= diff (set [ptc])) "Files in bucket do not match expected files")

--- a/test/ptc/e2e/system_test.clj
+++ b/test/ptc/e2e/system_test.clj
@@ -58,11 +58,11 @@
               pushes-files            (timeout 180000 #(gcs/wait-for-files-in-bucket pushed))]
           (is (not= pushes-files ::timed-out) "Timed out waiting for expected files to upload")
           (is (= (jms/jms->params workflow) (gcs/gcs-cat params))))))
-      (testing "Cromwell workflow is started by WFL"
-        (let [workflow-id (timeout 180000 #(wfl/wait-for-workflow-creation wfl-url chipwell-barcode analysis-version))]
-          (is (not= workflow-id ::timed-out) "Timeout waiting for workflow creation")
-          (is (uuid? (UUID/fromString workflow-id)) "Workflow id is not a valid UUID")
-          (testing "Cromwell workflow succeeds"
-            (let [workflow-timeout 1800000
-                  result (timeout workflow-timeout #(cromwell/wait-for-workflow-complete cromwell-url workflow-id))]
-              (is (= result "Succeeded") "Cromwell workflow failed")))))))
+    (testing "Cromwell workflow is started by WFL"
+      (let [workflow-id (timeout 180000 #(wfl/wait-for-workflow-creation wfl-url chipwell-barcode analysis-version))]
+        (is (not= workflow-id ::timed-out) "Timeout waiting for workflow creation")
+        (is (uuid? (UUID/fromString workflow-id)) "Workflow id is not a valid UUID")
+        (testing "Cromwell workflow succeeds"
+          (let [workflow-timeout 1800000
+                result (timeout workflow-timeout #(cromwell/wait-for-workflow-complete cromwell-url workflow-id))]
+            (is (= result "Succeeded") "Cromwell workflow failed")))))))

--- a/test/ptc/tools/gcs.clj
+++ b/test/ptc/tools/gcs.clj
@@ -123,7 +123,8 @@
 (defn wait-for-files-in-bucket
   "Wait for gsutil to successfully `stat` each given `gs://` file path.
 
-  If it returns, it will always return true."
+  Exists to block and will always return true when it returns. May block
+  forever."
   [files]
   (let [seconds 15
         file (first files)]

--- a/test/ptc/tools/gcs.clj
+++ b/test/ptc/tools/gcs.clj
@@ -136,8 +136,8 @@
               (do
                 (log/infof "Couldn't find %s, sleeping %s seconds" file seconds)
                 (.sleep TimeUnit/SECONDS seconds)
-                (recur)))
-            (log/infof "Found %s in bucket" file))
+                (recur))
+              (log/infof "Found %s in bucket" file)))
           (wait-for-files-in-bucket (rest files)))
       true)))
 

--- a/test/ptc/tools/jms.clj
+++ b/test/ptc/tools/jms.clj
@@ -19,7 +19,7 @@
   "CALL with the ENV JMS connection for testing."
   [env closure]
   (let [config {:prod {:url        "failover:ssl://vpicard-jms.broadinstitute.org:61616"
-                       :queue      "wfl.broad.pushtocloud.enqueue.prod"
+                       :queue      "wfl.broad.pushtocloud.enqueue.prod-test"
                        :vault-path "secret/dsde/gotc/prod/activemq/logins/zamboni"}
                 :dev  {:url        "failover:ssl://vpicard-jms-dev.broadinstitute.org:61616"
                        :queue      "wfl.broad.pushtocloud.enqueue.dev"


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- No ticket is linked to this PR.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Recurs based on `gsutil stat` having an exception rather than on parsing `gsutil ls` output.
- Reworks the test a tiny bit to no longer test the output of `gsutil ls` but rather the fact that everything could be `stat`ed with issue
- Make the "sleep" text a bit more useful so we can diagnose issues

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- This makes e2e pass consistently, you can try it locally.
