### PR TITLE
[GH-909] Fix test environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,16 @@ network and run:
 
 The e2e test runs in the dev environment by default. To run in production:
 ```bash
-QUEUE_ENVIRONMENT="prod"
+JMS_URL="failover:ssl://vpicard-jms.broadinstitute.org:61616"
+QUEUE="wfl.broad.pushtocloud.enqueue.prod-test"
+VAULT_PATH="secret/dsde/gotc/prod/activemq/logins/zamboni"
 PTC_BUCKET_URL="gs://broad-aou-arrays-input"
 CROMWELL_URL="https://cromwell-aou.gotc-prod.broadinstitute.org"
 WFL_URL="https://aou-wfl.gotc-prod.broadinstitute.org"
 
-QUEUE_ENVIRONMENT=${QUEUE_ENVIRONMENT} PTC_BUCKET_URL=${PTC_BUCKET_URL} \
-CROMWELL_URL=${CROMWELL_URL} WFL_URL=${WFL_URL} clojure -A:test integration
+JMS_URL=${JMS_URL} QUEUE=${QUEUE} VAULT_PATH=${VAULT_PATH} \
+PTC_BUCKET_URL=${PTC_BUCKET_URL} CROMWELL_URL=${CROMWELL_URL} WFL_URL=${WFL_URL} \
+clojure -A:test integration
 ```
 
 There's also an `ACL` testing to check if the permissions of (AoU) Bucket and Cromwell are in general set properly. You could invoke it with:

--- a/README.md
+++ b/README.md
@@ -63,14 +63,16 @@ network and run:
 
 The e2e test runs in the dev environment by default. To run in production:
 ```bash
-JMS_URL="failover:ssl://vpicard-jms.broadinstitute.org:61616"
-QUEUE="wfl.broad.pushtocloud.enqueue.prod-test"
-VAULT_PATH="secret/dsde/gotc/prod/activemq/logins/zamboni"
+ZAMBONI_ACTIVEMQ_SERVER_URL="failover:ssl://vpicard-jms.broadinstitute.org:61616"
+ZAMBONI_ACTIVEMQ_QUEUE_NAME="wfl.broad.pushtocloud.enqueue.prod-test"
+ZAMBONI_ACTIVEMQ_SECRET_PATH="secret/dsde/gotc/prod/activemq/logins/zamboni"
 PTC_BUCKET_URL="gs://broad-aou-arrays-input"
 CROMWELL_URL="https://cromwell-aou.gotc-prod.broadinstitute.org"
 WFL_URL="https://aou-wfl.gotc-prod.broadinstitute.org"
 
-JMS_URL=${JMS_URL} QUEUE=${QUEUE} VAULT_PATH=${VAULT_PATH} \
+ZAMBONI_ACTIVEMQ_SERVER_URL=${ZAMBONI_ACTIVEMQ_SERVER_URL} \
+ZAMBONI_ACTIVEMQ_QUEUE_NAME=${ZAMBONI_ACTIVEMQ_QUEUE_NAME} \
+ZAMBONI_ACTIVEMQ_SECRET_PATH=${ZAMBONI_ACTIVEMQ_SECRET_PATH} \
 PTC_BUCKET_URL=${PTC_BUCKET_URL} CROMWELL_URL=${CROMWELL_URL} WFL_URL=${WFL_URL} \
 clojure -A:test integration
 ```

--- a/README.md
+++ b/README.md
@@ -21,30 +21,6 @@ You could then run `clj -m $namespace` to run a module with given namespace. e.g
 clojure -m ptc.start
 ```
 
-The tests are managed by `clj` as well and will be executed by
- [`kaocha`](https://github.com/lambdaisland/kaocha) test runner. You could
- run the following code to see an example:
-
- ```bash
- clojure -A:test unit
- ```
-
-For integration testing, you need to connect to the VPN or be in the Broad
-network and run:
-
-```bash
- clojure -A:test integration
-```
-
-There's also an `ACL` testing to check if the permissions of (AoU) Bucket and Cromwell are in general set properly. You could invoke it with:
-
-```bash
- clojure -A:test acl
- ```
-
-which will run the end to end test including uploading some files to the
-testing Google Cloud Storage Bucket.
-
 ## Development
 
 ```bash
@@ -61,6 +37,49 @@ $ tree .
 The project structure is shown as above, you add new entries to `deps.edn`
 to introduce a new dependency, add new modules to `src/` and implement new
 test cases to `test/`.
+
+## Testing
+
+The tests are managed by `clj` and will be executed by
+ [`kaocha`](https://github.com/lambdaisland/kaocha) test runner. You could
+ run the following code to see an example:
+
+ ```bash
+ clojure -A:test unit
+ ```
+
+For integration testing, you need to connect to the VPN or be in the Broad
+network and run:
+
+```bash
+ clojure -A:test integration
+```
+
+For end-to-end testing, you need to connect to the VPN or be in the Broad
+network and run:
+```bash
+ clojure -A:test e2e
+```
+
+The e2e test runs in the dev environment by default. To run in production:
+```bash
+QUEUE_ENVIRONMENT="prod"
+PTC_BUCKET_URL="gs://broad-aou-arrays-input"
+CROMWELL_URL="https://cromwell-aou.gotc-prod.broadinstitute.org"
+WFL_URL="https://aou-wfl.gotc-prod.broadinstitute.org"
+
+QUEUE_ENVIRONMENT=${QUEUE_ENVIRONMENT} PTC_BUCKET_URL=${PTC_BUCKET_URL} \
+CROMWELL_URL=${CROMWELL_URL} WFL_URL=${WFL_URL} clojure -A:test integration
+```
+
+There's also an `ACL` testing to check if the permissions of (AoU) Bucket and Cromwell are in general set properly. You could invoke it with:
+
+```bash
+ clojure -A:test acl
+ ```
+
+which will run the end to end test including uploading some files to the
+testing Google Cloud Storage Bucket.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -63,17 +63,13 @@ network and run:
 
 The e2e test runs in the dev environment by default. To run in production:
 ```bash
-ZAMBONI_ACTIVEMQ_SERVER_URL="failover:ssl://vpicard-jms.broadinstitute.org:61616"
-ZAMBONI_ACTIVEMQ_QUEUE_NAME="wfl.broad.pushtocloud.enqueue.prod-test"
-ZAMBONI_ACTIVEMQ_SECRET_PATH="secret/dsde/gotc/prod/activemq/logins/zamboni"
-PTC_BUCKET_URL="gs://broad-aou-arrays-input"
-CROMWELL_URL="https://cromwell-aou.gotc-prod.broadinstitute.org"
-WFL_URL="https://aou-wfl.gotc-prod.broadinstitute.org"
+export ZAMBONI_ACTIVEMQ_SERVER_URL="failover:ssl://vpicard-jms.broadinstitute.org:61616"
+export ZAMBONI_ACTIVEMQ_QUEUE_NAME="wfl.broad.pushtocloud.enqueue.prod-test"
+export ZAMBONI_ACTIVEMQ_SECRET_PATH="secret/dsde/gotc/prod/activemq/logins/zamboni"
+export PTC_BUCKET_URL="gs://broad-aou-arrays-input"
+export CROMWELL_URL="https://cromwell-aou.gotc-prod.broadinstitute.org"
+export WFL_URL="https://aou-wfl.gotc-prod.broadinstitute.org"
 
-ZAMBONI_ACTIVEMQ_SERVER_URL=${ZAMBONI_ACTIVEMQ_SERVER_URL} \
-ZAMBONI_ACTIVEMQ_QUEUE_NAME=${ZAMBONI_ACTIVEMQ_QUEUE_NAME} \
-ZAMBONI_ACTIVEMQ_SECRET_PATH=${ZAMBONI_ACTIVEMQ_SECRET_PATH} \
-PTC_BUCKET_URL=${PTC_BUCKET_URL} CROMWELL_URL=${CROMWELL_URL} WFL_URL=${WFL_URL} \
 clojure -A:test integration
 ```
 

--- a/test/ptc/e2e/system_test.clj
+++ b/test/ptc/e2e/system_test.clj
@@ -11,8 +11,14 @@
   (:import [java.lang Integer]
            [java.util UUID]))
 
-(def queue-environment
-  (keyword (or (System/getenv "QUEUE_ENVIRONMENT") "dev")))
+(def jms-url
+  (keyword (or (System/getenv "JMS_URL") "failover:ssl://vpicard-jms-dev.broadinstitute.org:61616")))
+
+(def queue
+  (keyword (or (System/getenv "QUEUE") "wfl.broad.pushtocloud.enqueue.dev")))
+
+(def vault-path
+  (keyword (or (System/getenv "VAULT_PATH") "secret/dsde/gotc/dev/activemq/logins/zamboni")))
 
 (def bucket
   (or (System/getenv "PTC_BUCKET_URL") "gs://dev-aou-arrays-input"))
@@ -42,7 +48,7 @@
         chipwell-barcode (get-in message [::jms/Properties :payload :workflow :chipWellBarcode])
         workflow         (get-in message [::jms/Properties :payload :workflow])
         cloud-prefix     (jms/cloud-prefix bucket workflow)]
-    (jms-tools/queue-messages 1 queue-environment message)
+    (jms-tools/queue-messages 1 jms-url queue vault-path message)
     (testing "Files are uploaded to the input bucket"
       (let [params      (str cloud-prefix "/params.txt")
             ptc-file    (str cloud-prefix "/ptc.json")

--- a/test/ptc/e2e/system_test.clj
+++ b/test/ptc/e2e/system_test.clj
@@ -9,24 +9,19 @@
             [ptc.util.jms :as jms]
             [ptc.tools.jms :as jms-tools])
   (:import [java.lang Integer]
-           [java.util UUID]
-           [java.util.concurrent TimeUnit]))
+           [java.util UUID]))
 
-(def environment
-  (keyword (or (System/getenv "ENVIRONMENT") "dev")))
+(def queue-environment
+  (keyword (or (System/getenv "QUEUE_ENVIRONMENT") "dev")))
 
 (def bucket
-  (or (System/getenv "PTC_BUCKET_NAME") "gs://dev-aou-arrays-input"))
+  (or (System/getenv "PTC_BUCKET_URL") "gs://dev-aou-arrays-input"))
 
 (def cromwell-url
-  (if (= environment :prod)
-    "https://cromwell-aou.gotc-prod.broadinstitute.org"
-    "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org"))
+  (or (System/getenv "CROMWELL_URL") "https://cromwell-gotc-auth.gotc-dev.broadinstitute.org"))
 
 (def wfl-url
-  (if (= environment :prod)
-    "https://aou-wfl.gotc-prod.broadinstitute.org"
-    "https://dev-wfl.gotc-dev.broadinstitute.org"))
+  (or (System/getenv "WFL_URL") "https://dev-wfl.gotc-dev.broadinstitute.org"))
 
 (def jms-message
   (edn/read-string (slurp "./test/data/plumbing-test-jms-dev.edn")))
@@ -47,7 +42,7 @@
         chipwell-barcode (get-in message [::jms/Properties :payload :workflow :chipWellBarcode])
         workflow         (get-in message [::jms/Properties :payload :workflow])
         cloud-prefix     (jms/cloud-prefix bucket workflow)]
-    (jms-tools/queue-messages 1 environment message)
+    (jms-tools/queue-messages 1 queue-environment message)
     (testing "Files are uploaded to the input bucket"
       (let [params      (str cloud-prefix "/params.txt")
             ptc-file    (str cloud-prefix "/ptc.json")

--- a/test/ptc/e2e/system_test.clj
+++ b/test/ptc/e2e/system_test.clj
@@ -11,16 +11,16 @@
   (:import [java.lang Integer]
            [java.util UUID]))
 
-(def jms-url
-  (keyword (or (System/getenv "JMS_URL") "failover:ssl://vpicard-jms-dev.broadinstitute.org:61616")))
+(def zamboni-activemq-server-url
+  (keyword (or (System/getenv "ZAMBONI_ACTIVEMQ_SERVER_URL") "failover:ssl://vpicard-jms-dev.broadinstitute.org:61616")))
 
-(def queue
-  (keyword (or (System/getenv "QUEUE") "wfl.broad.pushtocloud.enqueue.dev")))
+(def zamboni-activemq-queue-name
+  (keyword (or (System/getenv "ZAMBONI_ACTIVEMQ_QUEUE_NAME") "wfl.broad.pushtocloud.enqueue.dev")))
 
-(def vault-path
-  (keyword (or (System/getenv "VAULT_PATH") "secret/dsde/gotc/dev/activemq/logins/zamboni")))
+(def zamboni-activemq-secret-path
+  (keyword (or (System/getenv "ZAMBONI_ACTIVEMQ_SECRET_PATH") "secret/dsde/gotc/dev/activemq/logins/zamboni")))
 
-(def bucket
+(def ptc-bucket-url
   (or (System/getenv "PTC_BUCKET_URL") "gs://dev-aou-arrays-input"))
 
 (def cromwell-url
@@ -47,8 +47,8 @@
                                    [::jms/Properties :payload :workflow :analysisCloudVersion] analysis-version)
         chipwell-barcode (get-in message [::jms/Properties :payload :workflow :chipWellBarcode])
         workflow         (get-in message [::jms/Properties :payload :workflow])
-        cloud-prefix     (jms/cloud-prefix bucket workflow)]
-    (jms-tools/queue-messages 1 jms-url queue vault-path message)
+        cloud-prefix     (jms/cloud-prefix ptc-bucket-url workflow)]
+    (jms-tools/queue-messages 1 zamboni-activemq-server-url zamboni-activemq-queue-name zamboni-activemq-secret-path message)
     (testing "Files are uploaded to the input bucket"
       (let [params      (str cloud-prefix "/params.txt")
             ptc-file    (str cloud-prefix "/ptc.json")

--- a/test/ptc/e2e/system_test.clj
+++ b/test/ptc/e2e/system_test.clj
@@ -12,13 +12,13 @@
            [java.util UUID]))
 
 (def zamboni-activemq-server-url
-  (keyword (or (System/getenv "ZAMBONI_ACTIVEMQ_SERVER_URL") "failover:ssl://vpicard-jms-dev.broadinstitute.org:61616")))
+  (or (System/getenv "ZAMBONI_ACTIVEMQ_SERVER_URL") "failover:ssl://vpicard-jms-dev.broadinstitute.org:61616"))
 
 (def zamboni-activemq-queue-name
-  (keyword (or (System/getenv "ZAMBONI_ACTIVEMQ_QUEUE_NAME") "wfl.broad.pushtocloud.enqueue.dev")))
+  (or (System/getenv "ZAMBONI_ACTIVEMQ_QUEUE_NAME") "wfl.broad.pushtocloud.enqueue.dev"))
 
 (def zamboni-activemq-secret-path
-  (keyword (or (System/getenv "ZAMBONI_ACTIVEMQ_SECRET_PATH") "secret/dsde/gotc/dev/activemq/logins/zamboni")))
+  (or (System/getenv "ZAMBONI_ACTIVEMQ_SECRET_PATH") "secret/dsde/gotc/dev/activemq/logins/zamboni"))
 
 (def ptc-bucket-url
   (or (System/getenv "PTC_BUCKET_URL") "gs://dev-aou-arrays-input"))

--- a/test/ptc/tools/jms.clj
+++ b/test/ptc/tools/jms.clj
@@ -54,7 +54,7 @@
 (defn -main
   [& args]
   (let [[n url queue vault-path] args
-        n (edn/read-string n)
+        n                (edn/read-string n)
         analysis-version (rand-int Integer/MAX_VALUE)
         where            [::jms/Properties :payload :workflow :analysisCloudVersion]
         jms-message      (edn/read-string (slurp "./test/data/plumbing-test-jms-dev.edn"))

--- a/test/ptc/tools/jms.clj
+++ b/test/ptc/tools/jms.clj
@@ -53,7 +53,7 @@
 
 (defn -main
   [& args]
-  (let [[n url queue vault-path] args
+  (let [[n zamboni-activemq-server-url zamboni-activemq-queue-name zamboni-activemq-secret-path] args
         n                (edn/read-string n)
         analysis-version (rand-int Integer/MAX_VALUE)
         where            [::jms/Properties :payload :workflow :analysisCloudVersion]
@@ -61,4 +61,4 @@
         message          (assoc-in jms-message where analysis-version)]
     (when-not (pos-int? n)
       (throw (IllegalArgumentException. "Must specify a positive integer")))
-    (queue-messages n url queue vault-path message)))
+    (queue-messages n zamboni-activemq-server-url zamboni-activemq-queue-name zamboni-activemq-secret-path message)))

--- a/test/ptc/tools/jms.clj
+++ b/test/ptc/tools/jms.clj
@@ -16,20 +16,11 @@
       (closure connection test-queue-name))))
 
 (defn with-queue-connection
-  "CALL with the ENV JMS connection for testing."
-  [env closure]
-  (let [config {:prod {:url        "failover:ssl://vpicard-jms.broadinstitute.org:61616"
-                       :queue      "wfl.broad.pushtocloud.enqueue.prod-test"
-                       :vault-path "secret/dsde/gotc/prod/activemq/logins/zamboni"}
-                :dev  {:url        "failover:ssl://vpicard-jms-dev.broadinstitute.org:61616"
-                       :queue      "wfl.broad.pushtocloud.enqueue.dev"
-                       :vault-path "secret/dsde/gotc/dev/activemq/logins/zamboni"}}]
-    (when-not (contains? config env)
-      (throw (IllegalArgumentException. (str "No such environment " (name env)))))
-    (let [{:keys [url queue vault-path]} (config env)
-          {:keys [username password]} (misc/vault-secrets vault-path)]
-      (with-open [connection (start/create-queue-connection url username password)]
-        (closure connection queue)))))
+  "CALL with the JMS URL, QUEUE and VAULT-PATH for testing."
+  [url queue vault-path closure]
+  (let [{:keys [username password]} (misc/vault-secrets vault-path)]
+    (with-open [connection (start/create-queue-connection url username password)]
+      (closure connection queue))))
 
 (def good-jms-message
   "Example JMS message for testing."
@@ -51,23 +42,23 @@
         (update-in content [::jms/Properties :payload :workflow] all)))))
 
 (defn queue-messages
-  "Queue N copies of MESSAGE to the ENV queue."
-  [n env message]
+  "Queue N copies of MESSAGE given a JMS URL, QUEUE and VAULT-PATH."
+  [n url queue vault-path message]
   (let [blame (or (System/getenv "USER") "aou-ptc-jms-test/queue-message")]
     (let [payload  (-> message jms/encode ::jms/Properties)
           enqueue! (fn [[con queue]] (start/produce con queue blame payload))]
-      (with-queue-connection env
+      (with-queue-connection url queue vault-path
         (fn [con queue]
           (run! enqueue! (repeat n [con queue])))))))
 
 (defn -main
   [& args]
-  (let [n                (edn/read-string (first args))
-        env              (edn/read-string (second args))
+  (let [[n url queue vault-path] args
+        n (edn/read-string n)
         analysis-version (rand-int Integer/MAX_VALUE)
         where            [::jms/Properties :payload :workflow :analysisCloudVersion]
         jms-message      (edn/read-string (slurp "./test/data/plumbing-test-jms-dev.edn"))
         message          (assoc-in jms-message where analysis-version)]
     (when-not (pos-int? n)
       (throw (IllegalArgumentException. "Must specify a positive integer")))
-    (queue-messages n (keyword env) message)))
+    (queue-messages n url queue vault-path message)))


### PR DESCRIPTION
### Purpose
https://broadinstitute.atlassian.net/browse/GH-909

### Changes
- Pass in specific environment variables to the e2e test instead of mapping based on an "environment" 
- Make the test default to dev

Note: This will require updating both Jenkins jobs that run the e2e test.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
