### PR TITLE
[GH-949] Update test buckets

### DIFF
--- a/test/data/reprocessing-jms.edn
+++ b/test/data/reprocessing-jms.edn
@@ -27,8 +27,8 @@
     :clioServer                                  "clioServer"
     :clioUseHttps                                true
     :cloudChipMetaDataDirectory                  "gs://storage/pipeline/arrays_metadata/PsychChip_v1-1_15073391_A1/"
-    :cloudGreenIdatPath                          "gs://broad-gotc-dev-zero-test/idats/bogus-green.idat"
-    :cloudRedIdatPath                            "gs://broad-gotc-dev-zero-test/idats/bogus-red.idat"
+    :cloudGreenIdatPath                          "gs://broad-gotc-dev-wfl-ptc-test-inputs/idats/bogus-green.idat"
+    :cloudRedIdatPath                            "gs://broad-gotc-dev-wfl-ptc-test-inputs/idats/bogus-red.idat"
     :cloudSoftwarePath                           "/seq/cloud/prod/software"
     :clusterFilePath                             "bogus-cluster.egt"
     :collaboratorParticipantId                   "3999595072"

--- a/test/ptc/integration/integration_test.clj
+++ b/test/ptc/integration/integration_test.clj
@@ -8,7 +8,7 @@
 
 (def bucket
   "Storage bucket for running ptc.integration test with."
-  "broad-gotc-dev-zero-test")
+  "broad-gotc-dev-wfl-ptc-test-outputs")
 
 (deftest integration
   (let [prefix     (str "test/" (UUID/randomUUID))

--- a/test/ptc/integration/jms_test.clj
+++ b/test/ptc/integration/jms_test.clj
@@ -11,7 +11,7 @@
 
 (def gcs-test-bucket
   "Throw test files in this bucket."
-  "broad-gotc-dev-zero-test")
+  "broad-gotc-dev-wfl-ptc-test-outputs")
 
 (defmacro with-temporary-gcs-folder
   "


### PR DESCRIPTION
### Purpose
Ticket: https://broadinstitute.atlassian.net/browse/GH-949

### Changes
- Change the output bucket to `broad-gotc-dev-wfl-ptc-test-outputs` which has a lifecycle policy that will delete all of that bucket's contents each day.
- Change the input bucket to `broad-gotc-dev-wfl-ptc-test-inputs`, which will be the new centralized location for all of the PTC & WFL test input files.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
