### PR TITLE
[GH-981] Use content-md5 header with gsutil cp

### DIFF
--- a/src/ptc/util/jms.clj
+++ b/src/ptc/util/jms.clj
@@ -148,7 +148,9 @@
               (if-let [path (v workflow)]
                 (assoc m k (str/join "/" [cloud (last (str/split path #"/"))]))
                 m))]
-      (apply misc/shell! "gsutil" "cp" (concat sources [cloud]))
+      (doseq [f sources]
+        (let [hash (misc/get-md5-hash f)]
+          (misc/shell! "gsutil" "-h" (str "Content-MD5:" hash) "cp" f cloud)))
       (reduce cloudify (reduce rekey {} copy) chip-and-push))))
 
 (def aou-reference-bucket

--- a/src/ptc/util/misc.clj
+++ b/src/ptc/util/misc.clj
@@ -143,3 +143,11 @@
   (when (string? path)
     (do-or-nil
      (shell! "gsutil" "stat" path))))
+
+(defn get-md5-hash
+  "Return the md5 hash of a file."
+  [path]
+  (-> (shell! "gsutil" "hash" "-m" path)
+      (str/split #":")
+      (last)
+      (str/trim)))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

Ticket: https://broadinstitute.atlassian.net/browse/GH-981

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

Use the content-md5 header with gsutil cp so that it will validate the file checksum before making it visible/accessible in the bucket: https://cloud.google.com/storage/docs/gsutil/commands/cp#checksum-validation

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
