### PR TITLE
[GH-1015] Add minor_allele_frequency_file to ptc.json

### DIFF
--- a/src/ptc/util/jms.clj
+++ b/src/ptc/util/jms.clj
@@ -33,6 +33,7 @@
    ::copy   true     :chip_well_barcode                   :chipWellBarcode
    ::copy   true     :cloud_chip_metadata_directory       :cloudChipMetaDataDirectory
    ::copy   true     :extended_illumina_manifest_filename :extendedIlluminaManifestFileName
+   ::copy   false    :minor_allele_frequency_file         :minorAlleleFrequencyFileCloudPath
    ::copy   true     :reported_gender                     :gender
    ::copy   true     :sample_alias                        :sampleAlias
    ::copy   true     :sample_lsid                         :sampleLsid

--- a/test/data/plumbing-test-jms-dev.edn
+++ b/test/data/plumbing-test-jms-dev.edn
@@ -24,6 +24,7 @@
             :genderClusterFilePath "/home/unix/ptc/data/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_gender.egt"
             :greenIDatPath "/home/unix/ptc/data/arrays/HumanExome-12v1-1_A/idats/7991775143_R01C01/7991775143_R01C01_Grn.idat"
             :labBatch "ARRAY-CO-5799466"
+            :minorAlleleFrequencyFileCloudPath "gs://storage/minor_allele_frequency.MAF.txt"
             :participantId "PT-97GM"
             :productFamily "Whole Genome Genotyping"
             :productName "Infinium Exome V1_A"


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

Ticket: https://broadinstitute.atlassian.net/browse/GH-1015

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

If a `minorAlleleFrequencyFileCloudPath` is in the JMS message, copy that file path to ptc.json under the key `minor_allele_frequency_file`.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
