### PR TITLE
[GH-1066] Swallow `gsutil stat` errors better

### DIFF
--- a/src/ptc/util/misc.clj
+++ b/src/ptc/util/misc.clj
@@ -148,7 +148,7 @@
   "Return PATH when there is a GCS object at PATH.  Otherwise nil."
   [path]
   (when (string? path)
-    (do-or-nil
+    (do-or-nil-silently
      (shell! "gsutil" "stat" path))))
 
 (defn get-md5-hash

--- a/src/ptc/util/misc.clj
+++ b/src/ptc/util/misc.clj
@@ -19,6 +19,13 @@
         (catch Exception x#
           (println x#))))
 
+(defmacro do-or-nil-silently
+  "Value of BODY or nil if it throws, without printing any exceptions.
+  See also [[do-or-nil]]."
+  [& body]
+  `(try (do ~@body)
+        (catch Exception x#)))
+
 (defmacro dump
   "Dump [EXPRESSION VALUE] where VALUE is EXPRESSION's value."
   [expression]

--- a/test/ptc/unit/util_test.clj
+++ b/test/ptc/unit/util_test.clj
@@ -1,6 +1,6 @@
 (ns ptc.unit.util-test
-  (:require [clojure.test :refer [deftest is testing]]
-            [clojure.edn :as edn]
+  (:require [clojure.test  :refer [deftest is testing]]
+            [clojure.edn   :as edn]
             [ptc.util.misc :as misc]
             [ptc.tools.gcs :as gcs])
   (:import (java.io StringWriter)))

--- a/test/ptc/unit/util_test.clj
+++ b/test/ptc/unit/util_test.clj
@@ -1,8 +1,9 @@
 (ns ptc.unit.util-test
-  (:require [clojure.test  :refer [deftest is testing]]
-            [clojure.edn   :as edn]
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.edn :as edn]
             [ptc.util.misc :as misc]
-            [ptc.tools.gcs  :as gcs]))
+            [ptc.tools.gcs :as gcs])
+  (:import (java.io StringWriter)))
 
 (deftest test-notify-everyone-on-the-list-with-message
   (letfn [(notify [msg to-list]
@@ -48,3 +49,21 @@
         (is (not (misc/message-ids-equal? test-msg test-msg-different))))
       (testing "not equal even if only one argument isn't"
         (is (not (misc/message-ids-equal? test-msg test-msg test-msg-different)))))))
+
+(deftest test-silent-stat
+  (testing "success case"
+    (let [output (StringWriter.)]
+      (testing "returns text"
+        (binding [*out* output
+                  *err* output]
+          (is (not (empty? (misc/gcs-object-exists? "--help"))))))
+      (testing "prints nothing"
+        (is (empty? (str output))))))
+  (testing "error case"
+    (let [output (StringWriter.)]
+      (testing "returns nothing"
+        (binding [*out* output
+                  *err* output]
+          (is (nil? (misc/gcs-object-exists? "non/gcs/path")))))
+      (testing "prints nothing"
+        (is (empty? (str output)))))))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1066

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- I grabbed the `do-or-nil-silently` function from WFL and used that instead of `do-or-nil` that explicitly prints output
- Added a test for the `gcs-object-exists?` to make sure it still works and is now silent

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Check the unit tests
