### PR TITLE
[GH-1042] Pass environment along

### DIFF
--- a/src/ptc/util/jms.clj
+++ b/src/ptc/util/jms.clj
@@ -32,6 +32,7 @@
    ::copy   true     :analysis_version_number             :analysisCloudVersion
    ::copy   true     :chip_well_barcode                   :chipWellBarcode
    ::copy   true     :cloud_chip_metadata_directory       :cloudChipMetaDataDirectory
+   ::copy   false    :environment                         :environment
    ::copy   true     :extended_illumina_manifest_filename :extendedIlluminaManifestFileName
    ::copy   false    :minor_allele_frequency_file         :minorAlleleFrequencyFileCloudPath
    ::copy   true     :reported_gender                     :gender

--- a/test/data/plumbing-test-jms-dev.edn
+++ b/test/data/plumbing-test-jms-dev.edn
@@ -18,6 +18,7 @@
             :cloudRedIdatPath "gs://storage/pipeline/RP-1044/NA12878/3999595072_R06C01/idats/3999595072_R06C01_Red.idat"
             :clusterFilePath "/home/unix/ptc/data/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt"
             :collaboratorParticipantId "NA12878"
+            :environment "dev"
             :extendedIlluminaManifestFileName "HumanExome-12v1-1_A.1.3.extended.csv"
             :extendedIlluminaManifestVersion "1.3"
             :gender "Female"


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1042

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Pass `environment` along if it exists
- Not required because WFL doesn't require it

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- I can't really think of any. We hit the same testing issue with `minor_allele_frequency_file`, the copying behavior in PTC isn't exposed for testing, it sorta just works. I'd rather not reinvent the wheel here--that'd be a lot of refactoring and test writing to make sure the refactoring didn't break anything. Maybe that's a future ticket, I dunno.
- This is just like #53 which is known-working
