### PR TITLE
[GH-1108] Make cloud-prefix env lowercase

### DIFF
--- a/src/ptc/util/jms.clj
+++ b/src/ptc/util/jms.clj
@@ -128,7 +128,7 @@
   "Return the cloud GCS URL with PREFIX for WORKFLOW."
   [prefix workflow]
   (let [{:keys [analysisCloudVersion chipName chipWellBarcode environment]} workflow]
-    (str/join "/" [prefix environment chipName chipWellBarcode analysisCloudVersion])))
+    (str/join "/" [prefix (str/lower-case environment) chipName chipWellBarcode analysisCloudVersion])))
 
 (defn push-params
   "Push a params.txt for the WORKFLOW into the cloud at PREFIX,


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

https://broadinstitute.atlassian.net/browse/GH-1108

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

The object names in google cloud storage are case-sensitive, so the `environment` in the JMS message should be lower-cased to ensure we only end up with one `staging/...` object in the bucket.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
