### PR TITLE
[GH-1146] Fix the e2e tests in dev.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -18,14 +18,14 @@
                   :extra-deps  {lambdaisland/kaocha {:mvn/version "1.0.629"}
                                 com.google.auth/google-auth-library-oauth2-http {:mvn/version "0.21.1"}}
                   :main-opts   ["-m" "kaocha.runner"]}
-           :build  {:extra-deps  {uberdeps {:mvn/version "0.1.10"}}
+           :build  {:extra-deps  {uberdeps/uberdeps {:mvn/version "0.1.10"}}
                     :main-opts   ["-e" "(compile,'ptc.start)"
                                   "-m" "uberdeps.uberjar"
                                   "--main-class" "ptc.start"
                                   "--multi-release"]}
-           :lint   {:extra-deps  {cljfmt {:mvn/version "0.6.8"}}
+           :lint   {:extra-deps  {cljfmt/cljfmt {:mvn/version "0.6.8"}}
                     :main-opts   ["-m" "cljfmt.main" "check"]}
-           :format {:extra-deps  {cljfmt {:mvn/version "0.6.8"}}
+           :format {:extra-deps  {cljfmt/cljfmt {:mvn/version "0.6.8"}}
                     :main-opts   ["-m" "cljfmt.main" "fix"]}
            :queue  {:extra-paths ["test"]
                     :main-opts   ["-m" "ptc.tools.jms"]}}

--- a/test/data/plumbing-test-jms-dev.edn
+++ b/test/data/plumbing-test-jms-dev.edn
@@ -38,6 +38,6 @@
             :sampleAlias "NA12878"
             :sampleId "SM-3S2IV"
             :sampleLsid "broadinstitute.org:bsp.dev.sample:NOTREAL.NA12878"
-            :vaultTokenPath "gs://storage/token"
+            :vaultTokenPath "gs://broad-dsp-gotc-arrays-dev-tokens/arrayswdl.token"
             :zCallThresholdsPath "/home/unix/ptc/data/arrays/metadata/HumanExome-12v1-1_A/IBDPRISM_EX.egt.thresholds.txt"}}
 }}

--- a/test/ptc/e2e/system_test.clj
+++ b/test/ptc/e2e/system_test.clj
@@ -37,7 +37,7 @@
   [milliseconds function]
   (let [f      (future (function))
         return (deref f milliseconds ::timed-out)]
-    (when (= return ::timed-out)
+    (when (= ::timed-out return)
       (future-cancel f))
     return))
 
@@ -53,17 +53,17 @@
       (let [params      (str cloud-prefix "/params.txt")
             ptc-file    (str cloud-prefix "/ptc.json")
             ptc-present (timeout 360000 #(gcs/wait-for-files-in-bucket [ptc-file]))]
-        (is (not= ptc-present ::timed-out) "Timed out waiting for ptc.json to upload")
+        (is (not= ::timed-out ptc-present) "Timed out waiting for ptc.json to upload")
         (let [{:keys [notifications]} (gcs/gcs-edn ptc-file)
               expected-files          (utils/pushed-files (first notifications) params)
               expected-present        (timeout 180000 #(gcs/wait-for-files-in-bucket expected-files))]
           (is (not= expected-present ::timed-out) "Timed out waiting for expected files to upload")
-          (is (= (jms/jms->params workflow) (gcs/gcs-cat params))))))
+          (is (= (gcs/gcs-cat params) (jms/jms->params workflow))))))
     (testing "Cromwell workflow is started by WFL"
       (let [workflow-id (timeout 180000 #(wfl/wait-for-workflow-creation wfl-url chipwell-barcode analysis-version))]
-        (is (not= workflow-id ::timed-out) "Timeout waiting for workflow creation")
+        (is (not= ::timed-out workflow-id ) "Timeout waiting for workflow creation")
         (is (uuid? (UUID/fromString workflow-id)) "Workflow id is not a valid UUID")
         (testing "Cromwell workflow succeeds"
           (let [workflow-timeout 1800000
                 result (timeout workflow-timeout #(cromwell/wait-for-workflow-complete cromwell-url workflow-id))]
-            (is (= result "Succeeded") "Cromwell workflow failed")))))))
+            (is (= "Succeeded" result) "Cromwell workflow failed")))))))

--- a/test/ptc/e2e/system_test.clj
+++ b/test/ptc/e2e/system_test.clj
@@ -61,7 +61,7 @@
           (is (= (gcs/gcs-cat params) (jms/jms->params workflow))))))
     (testing "Cromwell workflow is started by WFL"
       (let [workflow-id (timeout 180000 #(wfl/wait-for-workflow-creation wfl-url chipwell-barcode analysis-version))]
-        (is (not= ::timed-out workflow-id ) "Timeout waiting for workflow creation")
+        (is (not= ::timed-out workflow-id) "Timeout waiting for workflow creation")
         (is (uuid? (UUID/fromString workflow-id)) "Workflow id is not a valid UUID")
         (testing "Cromwell workflow succeeds"
           (let [workflow-timeout 1800000


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1146

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Use a real dev token for the testing JMS message.
- Correct the order of the testing assertions so it works like: `(= Expected Actual)`.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Why it didn't fail before? Because WFL used to have a default value for this field, as it's always `dev` in the past. Now WFL starts to use the value from this field to override its own default one! Check [here](https://github.com/broadinstitute/wfl/commit/5b53b8b0a74e305752767fcf0e47b340bb2cf0da#diff-4cb7e9e206a00497d94cf3e30972efa1e5e2472df4c308021988be535614503a) for details.
