### PR TITLE
Maybe ^:exclude the ACL test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,28 @@ export WFL_URL="https://aou-wfl.gotc-prod.broadinstitute.org"
 clojure -A:test integration
 ```
 
-There's also an `ACL` testing to check if the permissions of (AoU) Bucket and Cromwell are in general set properly. You could invoke it with:
+There is another test target named `acl-in-production`.
+That runs a test
+that includes reading from and writing to
+the production Google Cloud Storage buckets.
+The `acl-in-production` test is disabled
+because it runs in production
+and can break the AllOfUs pipeline.
+Do not run it while the AllOfUs pipeline is in use.
+
+You can edit code to enable the test
+after you've verified that no samples
+are in the AllOfUs pipeline,
+and run it like this:
 
 ```bash
- clojure -A:test acl
- ```
+ clojure -A:test acl-in-production
+```
 
-which will run the end to end test including uploading some files to the
-testing Google Cloud Storage Bucket.
+The `acl-in-production` test verifies
+that the permissions on the production AllOfUs buckets
+and the production Cromwell are set properly.
+
 
 ## Build
 

--- a/test/ptc/acl/permission_test.clj
+++ b/test/ptc/acl/permission_test.clj
@@ -37,7 +37,7 @@
                       .refreshAccessToken .getTokenValue)]
     {"Authorization" (str/join \space ["Bearer" token])}))
 
-(deftest bucket-permission-test
+(deftest ^:excluded bucket-permission-test
   (testing "Unauthorized user cannot list the PTC buckets."
     (with-redefs [gcs/get-auth-header! get-test-user-header]
       (try
@@ -75,7 +75,7 @@
           (is (contains? #{403 404} (:status (ex-data e)))
               "The user is able to delete object from the output bucket!!"))))))
 
-(deftest workflow-permission-test
+(deftest ^:excluded workflow-permission-test
   (testing "Unauthorized users cannot query for workflows in the AoU Cromwell."
     (try
       (with-redefs [gcs/get-auth-header! get-test-user-header]

--- a/test/ptc/acl/production_permission_test.clj
+++ b/test/ptc/acl/production_permission_test.clj
@@ -29,12 +29,14 @@
 (defn get-test-user-header
   "Generate auth header from the ACL test user service account."
   []
-  (let [token (some-> test-user misc/vault-secrets (:value) .getBytes
+  (let [scope ["https://www.googleapis.com/auth/cloud-platform"
+               "https://www.googleapis.com/auth/userinfo.email"
+               "https://www.googleapis.com/auth/userinfo.profile"]
+        token (some-> test-user misc/vault-secrets (:value) .getBytes
                       io/input-stream GoogleCredentials/fromStream
-                      (.createScoped ["https://www.googleapis.com/auth/cloud-platform"
-                                      "https://www.googleapis.com/auth/userinfo.email"
-                                      "https://www.googleapis.com/auth/userinfo.profile"])
+                      (.createScoped scope)
                       .refreshAccessToken .getTokenValue)]
+    (is token "No credentials for test-user.")
     {"Authorization" (str/join \space ["Bearer" token])}))
 
 (deftest ^:excluded bucket-permission-test

--- a/test/ptc/acl/production_permission_test.clj
+++ b/test/ptc/acl/production_permission_test.clj
@@ -1,4 +1,4 @@
-(ns ptc.acl.permission-test
+(ns ptc.acl.production-permission-test
   "Test that the right permissions are granted for AoU project."
   (:require [ptc.tools.gcs :as gcs]
             [ptc.tools.cromwell :as cromwell]

--- a/test/ptc/acl/production_permission_test.clj
+++ b/test/ptc/acl/production_permission_test.clj
@@ -38,6 +38,7 @@
     {"Authorization" (str/join \space ["Bearer" token])}))
 
 (deftest ^:excluded bucket-permission-test
+  (is false "Do you really want to run this in production?")
   (testing "Unauthorized user cannot list the PTC buckets."
     (with-redefs [gcs/get-auth-header! get-test-user-header]
       (try
@@ -76,6 +77,7 @@
               "The user is able to delete object from the output bucket!!"))))))
 
 (deftest ^:excluded workflow-permission-test
+  (is false "Do you really want to run this in production?")
   (testing "Unauthorized users cannot query for workflows in the AoU Cromwell."
     (try
       (with-redefs [gcs/get-auth-header! get-test-user-header]

--- a/tests.edn
+++ b/tests.edn
@@ -7,7 +7,7 @@
                       :kaocha/ns-patterns      ["ptc\\.integration\\..*-test$"]}
                      {:kaocha.testable/id      :e2e
                       :kaocha/ns-patterns      ["ptc\\.e2e\\..*-test$"]}
-                     {:kaocha.testable/id      :acl
+                     {:kaocha.testable/id      :acl-in-production
                       :kaocha/ns-patterns      ["ptc\\.acl\\..*-test$"]
                       :kaocha.filter/skip-meta [:excluded]}]
  :kaocha/fail-fast? true

--- a/tests.edn
+++ b/tests.edn
@@ -1,15 +1,16 @@
 ;; Configuration file for Kaocha test runner
 ;;
 #kaocha/v1
-    {:tests             [{:kaocha.testable/id :unit,
-                          :kaocha/ns-patterns ["ptc\\.unit\\..*-test$"]}
-                         {:kaocha.testable/id :integration,
-                          :kaocha/ns-patterns ["ptc\\.integration\\..*-test$"]}
-                         {:kaocha.testable/id :e2e,
-                          :kaocha/ns-patterns ["ptc\\.e2e\\..*-test$"]}
-                         {:kaocha.testable/id :acl,
-                          :kaocha/ns-patterns ["ptc\\.acl\\..*-test$"]}]
-     :kaocha/fail-fast? true
-     :color?            true
-     :reporter          [kaocha.report/documentation]
-     :capture-output?   true}
+{:tests             [{:kaocha.testable/id      :unit,
+                      :kaocha/ns-patterns      ["ptc\\.unit\\..*-test$"]}
+                     {:kaocha.testable/id      :integration,
+                      :kaocha/ns-patterns      ["ptc\\.integration\\..*-test$"]}
+                     {:kaocha.testable/id      :e2e,
+                      :kaocha/ns-patterns      ["ptc\\.e2e\\..*-test$"]}
+                     {:kaocha.testable/id      :acl,
+                      :kaocha/ns-patterns      ["ptc\\.acl\\..*-test$"]
+                      :kaocha.filter/skip-meta [:excluded]}]
+ :kaocha/fail-fast? true
+ :color?            true
+ :reporter          [kaocha.report/documentation]
+ :capture-output?   true}

--- a/tests.edn
+++ b/tests.edn
@@ -1,13 +1,13 @@
 ;; Configuration file for Kaocha test runner
 ;;
 #kaocha/v1
-{:tests             [{:kaocha.testable/id      :unit,
+{:tests             [{:kaocha.testable/id      :unit
                       :kaocha/ns-patterns      ["ptc\\.unit\\..*-test$"]}
-                     {:kaocha.testable/id      :integration,
+                     {:kaocha.testable/id      :integration
                       :kaocha/ns-patterns      ["ptc\\.integration\\..*-test$"]}
-                     {:kaocha.testable/id      :e2e,
+                     {:kaocha.testable/id      :e2e
                       :kaocha/ns-patterns      ["ptc\\.e2e\\..*-test$"]}
-                     {:kaocha.testable/id      :acl,
+                     {:kaocha.testable/id      :acl
                       :kaocha/ns-patterns      ["ptc\\.acl\\..*-test$"]
                       :kaocha.filter/skip-meta [:excluded]}]
  :kaocha/fail-fast? true


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1351

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Maybe ^:exclude the ACL test.
- Retained because it does add some value to the e2e test.
- It verifies the the ACL is restricted enough to forbid just anyone from reading the buckets, for example.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- Please look this over and let me know what you think.
- There are now several obstacles to running this test by mistake.
- It now has `production` in its name.
- It is `:excluded` by default.
- It fails with a warning message unless it is edited to enable the test.
- Do we want to keep this test or just delete it?
- If we want to keep it, how many of these obstacles should we retain?
- Can you think of a better way?