### PR TITLE
Redirect messages to dead letter queue on exception.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The e2e test runs in the dev environment by default. To run in production:
 ```bash
 export ZAMBONI_ACTIVEMQ_SERVER_URL="failover:ssl://vpicard-jms.broadinstitute.org:61616"
 export ZAMBONI_ACTIVEMQ_QUEUE_NAME="wfl.broad.pushtocloud.enqueue.prod-test"
+export ZAMBONI_ACTIVEMQ_DEAD_LETTER_QUEUE_NAME="wfl.broad.pushtocloud.enqueue.prod-test-dlq"
 export ZAMBONI_ACTIVEMQ_SECRET_PATH="secret/dsde/gotc/prod/activemq/logins/zamboni"
 export PTC_BUCKET_URL="gs://broad-aou-arrays-input"
 export CROMWELL_URL="https://cromwell-aou.gotc-prod.broadinstitute.org"

--- a/src/ptc/start.clj
+++ b/src/ptc/start.clj
@@ -86,8 +86,8 @@
               (log/infof "Task complete, consumed message %s" counter)
               (if (not (misc/message-ids-equal? peeked consumed))
                 (log/warnf
-                  (str/join \space ["Messages differ:"
-                                    (with-out-str (pprint (data/diff peeked consumed)))])))
+                 (str/join \space ["Messages differ:"
+                                   (with-out-str (pprint (data/diff peeked consumed)))])))
               (recur (inc counter))))))
       (recur counter))))
 
@@ -105,9 +105,9 @@
                                           (catch Throwable x
                                             (produce connection dead-letter-queue (str misc/utc-now) jms)
                                             (log/errorf
-                                              (str/join
-                                                \space ["Task returned nil/false,"
-                                                        "not consuming message %s, moving it to dead letter queue and continue..."])))
+                                             (str/join
+                                              \space ["Task returned nil/false,"
+                                                      "not consuming message %s, moving it to dead letter queue and continue..."])))
                                           (finally true)))
         {:keys [username password]} (misc/vault-secrets vault-path)]
     (try

--- a/src/ptc/start.clj
+++ b/src/ptc/start.clj
@@ -105,25 +105,25 @@
   "Loop and consume messages using the Zamboni ActiveMQ server."
   []
   (let [queue               (misc/getenv-or-throw "ZAMBONI_ACTIVEMQ_QUEUE_NAME")
-        dead-letter-queue   (misc/getenv-or-throw "ZAMBONI_ACTIVEMQ_DEAD_LETTER_QUEUE_NAME")
+        dlq                 (misc/getenv-or-throw "ZAMBONI_ACTIVEMQ_DEAD_LETTER_QUEUE_NAME")
         url                 (misc/getenv-or-throw "ZAMBONI_ACTIVEMQ_SERVER_URL")
         vault-path          (misc/getenv-or-throw "ZAMBONI_ACTIVEMQ_SECRET_PATH")
         bucket-url          (misc/getenv-or-throw "PTC_BUCKET_URL")
         {:keys [username password]} (misc/vault-secrets vault-path)]
-    (letfn [(upload-sample-or-move-to-dlq! [jms connection] (try
-                                                              (jms/handle-message bucket-url jms)
-                                                              (catch Throwable x
-                                                                (log/errorf
-                                                                 (str/join
-                                                                  \space ["Failed to handle the message %s due to %s"
-                                                                          "moving it to dead letter queue and continue..."])
-                                                                 x jms)
-                                                                (produce connection dead-letter-queue (str x) jms))
+    (letfn [(handle-or-dlq! [jms connection] (try
+                                               (jms/handle-message bucket-url jms)
+                                               (catch Throwable x
+                                                 (log/errorf
+                                                  (str/join
+                                                   \space ["Failed to handle the message %s due to %s"
+                                                           "moving it to %s and continue..."])
+                                                  x jms dlq)
+                                                 (produce connection dlq (str x) jms))
                                                               ;; so the jms message is always consumed from main queue
-                                                              (finally true)))]
+                                               (finally true)))]
       (try
         (with-open [connection (create-queue-connection url username password)]
-          (listen-and-consume-from-queue upload-sample-or-move-to-dlq! connection queue))
+          (listen-and-consume-from-queue handle-or-dlq! connection queue))
         (catch Throwable x
           (log/fatal x "Fatal error in message loop")
           (System/exit 1))))))

--- a/src/ptc/util/misc.clj
+++ b/src/ptc/util/misc.clj
@@ -180,7 +180,3 @@
       (last)
       (str/trim)))
 
-(defn utc-now
-  "Return OffsetDateTime/now in UTC."
-  []
-  (OffsetDateTime/now (ZoneId/of "UTC")))

--- a/src/ptc/util/misc.clj
+++ b/src/ptc/util/misc.clj
@@ -12,6 +12,7 @@
   (:import [java.util UUID]
            [java.util.concurrent TimeUnit]
            [org.apache.commons.mail SimpleEmail]
+           [java.time OffsetDateTime ZoneId]
            (java.io IOException)))
 
 (defmacro do-or-nil
@@ -178,3 +179,8 @@
       (str/split #":")
       (last)
       (str/trim)))
+
+(defn utc-now
+  "Return OffsetDateTime/now in UTC."
+  []
+  (OffsetDateTime/now (ZoneId/of "UTC")))

--- a/test/ptc/e2e/system_test.clj
+++ b/test/ptc/e2e/system_test.clj
@@ -17,6 +17,9 @@
 (def zamboni-activemq-queue-name
   (or (System/getenv "ZAMBONI_ACTIVEMQ_QUEUE_NAME") "wfl.broad.pushtocloud.enqueue.dev"))
 
+(def zamboni-activemq-dead-letter-queue-name
+  (or (System/getenv "ZAMBONI_ACTIVEMQ_DEAD_LETTER_QUEUE_NAME") "wfl.broad.pushtocloud.enqueue.dev-dlq"))
+
 (def zamboni-activemq-secret-path
   (or (System/getenv "ZAMBONI_ACTIVEMQ_SECRET_PATH") "secret/dsde/gotc/dev/activemq/logins/zamboni"))
 

--- a/test/ptc/integration/integration_test.clj
+++ b/test/ptc/integration/integration_test.clj
@@ -20,6 +20,7 @@
                     (gcs/upload-file "deps.edn" bucket object)
                     (gcs/list-objects bucket object)
                     (finally (gcs/delete-object bucket object)))))
+              ;; to break out from the loop
               false)
             (flow [connection queue]
               (start/produce connection queue "text" properties)

--- a/test/ptc/integration/integration_test.clj
+++ b/test/ptc/integration/integration_test.clj
@@ -13,7 +13,7 @@
 (deftest integration
   (let [prefix     (str "test/" (UUID/randomUUID))
         properties (::jms/Properties (jms/encode @jms-tools/good-jms-message))]
-    (letfn [(task [_]
+    (letfn [(task [_ _]
               (testing "upload a file to the bucket"
                 (let [object (str prefix "/deps.edn")]
                   (try
@@ -31,7 +31,7 @@
 
 (deftest peeking
   (let [properties (::jms/Properties (jms/encode @jms-tools/good-jms-message))]
-    (letfn [(task [message] (is message) false)]
+    (letfn [(task [message _] (is message) false)]
       (jms-tools/with-test-queue-connection
         (fn [connection queue]
           (testing "Message given to task isn't nil"


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- No ticket is linked to this PR.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Redirect messages to dead letter queue on exception.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

Question:

I added a new ENV `ZAMBONI_ACTIVEMQ_DEAD_LETTER_QUEUE_NAME`, but cannot be able to find where it's configured for deployment, does any one know where does `push-to-cloud.config` live?
