### PR TITLE
Fix the AoU/PtC end-to-end test in development.

### DIFF
--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -3,7 +3,7 @@
 This file configures Log4j 2.
 Its syntax is given by https://logging.apache.org/log4j/2.x/manual/configuration.html
 -->
-<Configuration status="DEBUG">
+<Configuration status="WARN">
     <Properties>
         <Property name="pattern">%d{hh:mm:ss} %-5level %logger{36} - %msg%n</Property>
     </Properties>

--- a/resources/log4j2.xml
+++ b/resources/log4j2.xml
@@ -3,7 +3,7 @@
 This file configures Log4j 2.
 Its syntax is given by https://logging.apache.org/log4j/2.x/manual/configuration.html
 -->
-<Configuration status="WARN">
+<Configuration status="DEBUG">
     <Properties>
         <Property name="pattern">%d{hh:mm:ss} %-5level %logger{36} - %msg%n</Property>
     </Properties>

--- a/src/ptc/util/jms.clj
+++ b/src/ptc/util/jms.clj
@@ -195,7 +195,7 @@
 (defn get-extended-chip-manifest
   "Get the extended_chip_manifest_file from _WORKFLOW."
   [{:keys [cloudChipMetaDataDirectory extendedIlluminaManifestFileName]
-    :as _workflow}]
+    :as   _workflow}]
   (let [[bucket _] (gcs/parse-gs-url cloudChipMetaDataDirectory)]
     (str (str/replace-first cloudChipMetaDataDirectory
                             bucket aou-reference-bucket)

--- a/test/data/bad-jms.edn
+++ b/test/data/bad-jms.edn
@@ -26,7 +26,7 @@
     :clioPort                                    443
     :clioServer                                  "clioServer"
     :clioUseHttps                                true
-    :cloudChipMetaDataDirectory                  "gs://broad-arrays-prod-storage/pipeline/arrays_metadata/PsychChip_v1-1_15073391_A1/"
+    :cloudChipMetaDataDirectory                  "gs://broad-arrays-dev-storage/pipeline/arrays_metadata/PsychChip_v1-1_15073391_A1/"
     :cloudSoftwarePath                           "/seq/cloud/prod/software"
     :clusterFilePath                             "bogus-cluster.egt"
     ;; :collaboratorParticipantId                "3999595072" ; FAIL!

--- a/test/data/bad-jms.edn
+++ b/test/data/bad-jms.edn
@@ -26,7 +26,7 @@
     :clioPort                                    443
     :clioServer                                  "clioServer"
     :clioUseHttps                                true
-    :cloudChipMetaDataDirectory                  "gs://storage/pipeline/arrays_metadata/PsychChip_v1-1_15073391_A1/"
+    :cloudChipMetaDataDirectory                  "gs://broad-arrays-prod-storage/pipeline/arrays_metadata/PsychChip_v1-1_15073391_A1/"
     :cloudSoftwarePath                           "/seq/cloud/prod/software"
     :clusterFilePath                             "bogus-cluster.egt"
     ;; :collaboratorParticipantId                "3999595072" ; FAIL!

--- a/test/data/good-jms.edn
+++ b/test/data/good-jms.edn
@@ -26,7 +26,7 @@
     :clioPort                                    443
     :clioServer                                  "clioServer"
     :clioUseHttps                                true
-    :cloudChipMetaDataDirectory                  "gs://storage/pipeline/arrays_metadata/PsychChip_v1-1_15073391_A1/"
+    :cloudChipMetaDataDirectory                  "gs://broad-arrays-prod-storage/pipeline/arrays_metadata/PsychChip_v1-1_15073391_A1/"
     :cloudSoftwarePath                           "/seq/cloud/prod/software"
     :clusterFilePath                             "bogus-cluster.egt"
     :collaboratorParticipantId                   "3999595072"

--- a/test/data/good-jms.edn
+++ b/test/data/good-jms.edn
@@ -26,7 +26,7 @@
     :clioPort                                    443
     :clioServer                                  "clioServer"
     :clioUseHttps                                true
-    :cloudChipMetaDataDirectory                  "gs://broad-arrays-prod-storage/pipeline/arrays_metadata/PsychChip_v1-1_15073391_A1/"
+    :cloudChipMetaDataDirectory                  "gs://broad-arrays-dev-storage/pipeline/arrays_metadata/PsychChip_v1-1_15073391_A1/"
     :cloudSoftwarePath                           "/seq/cloud/prod/software"
     :clusterFilePath                             "bogus-cluster.egt"
     :collaboratorParticipantId                   "3999595072"

--- a/test/data/plumbing-test-jms-dev.edn
+++ b/test/data/plumbing-test-jms-dev.edn
@@ -13,7 +13,7 @@
     :chipManifestPath "/home/unix/ptc/data/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv"
     :chipName "HumanExome-12v1-1_A"
     :chipWellBarcode "7991775143_R01C01"
-    :cloudChipMetaDataDirectory "gs://storage/pipeline/arrays_metadata/HumanExome-12v1-1_A/"
+    :cloudChipMetaDataDirectory "gs://broad-arrays-prod-storage/pipeline/arrays_metadata/HumanExome-12v1-1_A/"
     :clusterFilePath "/home/unix/ptc/data/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt"
     :collaboratorParticipantId "NA12878"
     :environment "dev"

--- a/test/data/plumbing-test-jms-dev.edn
+++ b/test/data/plumbing-test-jms-dev.edn
@@ -13,7 +13,7 @@
     :chipManifestPath "/home/unix/ptc/data/arrays/metadata/HumanExome-12v1-1_A/HumanExome-12v1-1_A.1.3.extended.csv"
     :chipName "HumanExome-12v1-1_A"
     :chipWellBarcode "7991775143_R01C01"
-    :cloudChipMetaDataDirectory "gs://broad-arrays-prod-storage/pipeline/arrays_metadata/HumanExome-12v1-1_A/"
+    :cloudChipMetaDataDirectory "gs://broad-arrays-dev-storage/pipeline/arrays_metadata/HumanExome-12v1-1_A/"
     :clusterFilePath "/home/unix/ptc/data/arrays/metadata/HumanExome-12v1-1_A/HumanExomev1_1_CEPH_A.egt"
     :collaboratorParticipantId "NA12878"
     :environment "dev"

--- a/test/data/reprocessing-jms.edn
+++ b/test/data/reprocessing-jms.edn
@@ -26,7 +26,7 @@
     :clioPort                                    443
     :clioServer                                  "clioServer"
     :clioUseHttps                                true
-    :cloudChipMetaDataDirectory                  "gs://storage/pipeline/arrays_metadata/PsychChip_v1-1_15073391_A1/"
+    :cloudChipMetaDataDirectory                  "gs://broad-arrays-prod-storage/pipeline/arrays_metadata/PsychChip_v1-1_15073391_A1/"
     :cloudSoftwarePath                           "/seq/cloud/prod/software"
     :clusterFilePath                             "bogus-cluster.egt"
     :collaboratorParticipantId                   "3999595072"

--- a/test/data/reprocessing-jms.edn
+++ b/test/data/reprocessing-jms.edn
@@ -26,7 +26,7 @@
     :clioPort                                    443
     :clioServer                                  "clioServer"
     :clioUseHttps                                true
-    :cloudChipMetaDataDirectory                  "gs://broad-arrays-prod-storage/pipeline/arrays_metadata/PsychChip_v1-1_15073391_A1/"
+    :cloudChipMetaDataDirectory                  "gs://broad-arrays-dev-storage/pipeline/arrays_metadata/PsychChip_v1-1_15073391_A1/"
     :cloudSoftwarePath                           "/seq/cloud/prod/software"
     :clusterFilePath                             "bogus-cluster.egt"
     :collaboratorParticipantId                   "3999595072"

--- a/test/ptc/e2e/system_test.clj
+++ b/test/ptc/e2e/system_test.clj
@@ -55,9 +55,9 @@
               "Timed out waiting for expected files to upload")
           (is (= (gcs/gcs-cat params) (jms/jms->params workflow))))))
     (testing "WFL starts Cromwell workflow"
-      (let [workflow-id (timeout 3 #(wfl/wait-for-workflow-creation
-                                     (env/getenv-or-throw "WFL_URL")
-                                     chipWellBarcode analysisCloudVersion))]
+      (let [workflow-id (timeout 23 #(wfl/wait-for-workflow-creation
+                                      (env/getenv-or-throw "WFL_URL")
+                                      chipWellBarcode analysisCloudVersion))]
         (is (not= (timeout) workflow-id) "wait-for-workflow-creation timed out")
         (is (uuid? (UUID/fromString workflow-id)) "workflow-id is not a UUID")
         (testing "Cromwell workflow succeeds"

--- a/test/ptc/e2e/system_test.clj
+++ b/test/ptc/e2e/system_test.clj
@@ -15,10 +15,10 @@
 (defn ^:private timeout
   "Timeout FUNCTION after MINUTES."
   ([] ::timed-out)
-  ([seconds function]
+  ([minutes function]
    (let [cancel (timeout)
          ff     (future (function))
-         result (deref ff (* 60 1000 seconds) cancel)]
+         result (deref ff (* 60 1000 minutes) cancel)]
      (when (= cancel result)
        (future-cancel ff))
      result)))
@@ -54,14 +54,12 @@
                                               gcs/wait-for-files)))
               "Timed out waiting for expected files to upload")
           (is (= (gcs/gcs-cat params) (jms/jms->params workflow))))))
-    (testing "Cromwell workflow is started by WFL"
+    (testing "WFL starts Cromwell workflow"
       (let [workflow-id (timeout 3 #(wfl/wait-for-workflow-creation
                                      (env/getenv-or-throw "WFL_URL")
                                      chipWellBarcode analysisCloudVersion))]
-        (is (not= (timeout) workflow-id)
-            "Timeout waiting for workflow creation")
-        (is (uuid? (UUID/fromString workflow-id))
-            "Workflow id is not a valid UUID")
+        (is (not= (timeout) workflow-id) "wait-for-workflow-creation timed out")
+        (is (uuid? (UUID/fromString workflow-id)) "workflow-id is not a UUID")
         (testing "Cromwell workflow succeeds"
           (let [result (timeout 60 #(cromwell/wait-for-workflow-complete
                                      (env/getenv-or-throw "CROMWELL_URL")

--- a/test/ptc/tools/cromwell.clj
+++ b/test/ptc/tools/cromwell.clj
@@ -45,7 +45,7 @@
   [cromwell-url id]
   (work-around-cromwell-fail-bug 9 cromwell-url id)
   (loop [cromwell-url cromwell-url id id]
-    (let [seconds 15
+    (let [seconds 60
           now (status cromwell-url id)]
       (if (#{"Submitted" "Running"} now)
         (do (log/infof "%s: Sleeping %s seconds on status: %s"

--- a/test/ptc/tools/cromwell.clj
+++ b/test/ptc/tools/cromwell.clj
@@ -1,6 +1,7 @@
 (ns ptc.tools.cromwell
   "Utility functions for Cromwell."
   (:require [clojure.data.json :as json]
+            [clojure.string :as str]
             [clojure.tools.logging :as log]
             [clj-http.client :as client]
             [ptc.tools.gcs :as gcs]
@@ -9,9 +10,12 @@
 (defn status
   "Status of the workflow with ID at CROMWELL-URL."
   [cromwell-url id]
-  (->> (str cromwell-url "/api/workflows/v1/" id "/status")
-       (client/get {:headers (misc/get-auth-header!)})
-       :body misc/parse-json-string :status))
+  (let [url (str/join "/" [cromwell-url "api" "workflows" "v1" id "status"])]
+    (->>  {:method       :get           ; :debug true :debug-body true
+           :content-type :application/json
+           :url          url
+           :headers      (misc/get-auth-header!)}
+          client/request :body misc/parse-json-string :status)))
 
 (defn query
   "Query for a workflow with ID at CROMWELL-URL."

--- a/test/ptc/tools/wfl.clj
+++ b/test/ptc/tools/wfl.clj
@@ -48,10 +48,10 @@
   [wfl-url chipwell-barcode analysis-version-number]
   (letfn [(fetch! [] (get-aou-workflow-ids
                       wfl-url chipwell-barcode analysis-version-number))]
-    (let [seconds 15]
+    (let [seconds 60]
       (loop [ids (fetch!)]
         (if (empty? ids)
-          (do (log/infof "Sleeping %s seconds" seconds)
+          (do (log/infof "wait-for-workflow-creation: Sleep %s seconds" seconds)
               (misc/sleep-seconds seconds)
               (recur (fetch!)))
           (first ids))))))


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1536

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- Fix the system end-to-end test in dev.
- Find chip metadata in `cloudChipMetaDataDirectory`.
- Fix cast exception because Cromwell evidently requires `Content-type` now.
- Extend timeout when waiting for workflow creation.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- The interesting changes are in `test/ptc/e2e/system_test.clj` and `test/ptc/tools/cromwell.clj`.
- Also replaced bogus `gs://storage/` URLs with real GCS folders containing the chip metadata.