### PR TITLE
GH-1561 Upgrade PTC Log4J to 2.17.0

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,9 +5,9 @@
            org.clojure/tools.logging                 {:mvn/version "1.2.1"}
            org.apache.activemq/activemq-core         {:mvn/version "5.7.0"}
            org.apache.tika/tika-core                 {:mvn/version "2.1.0"}
-           org.apache.logging.log4j/log4j-api        {:mvn/version "2.16.0"}
-           org.apache.logging.log4j/log4j-core       {:mvn/version "2.16.0"}
-           org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.16.0"}
+           org.apache.logging.log4j/log4j-api        {:mvn/version "2.17.0"}
+           org.apache.logging.log4j/log4j-core       {:mvn/version "2.17.0"}
+           org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.17.0"}
            org.slf4j/slf4j-api                       {:mvn/version "1.7.32"}
            amperity/vault-clj                        {:mvn/version "1.0.6"}
            clj-http/clj-http                         {:mvn/version "3.9.1"}


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any ticket that it fixes: -->

- https://broadinstitute.atlassian.net/browse/GH-1561

This newer version of Log4J helps guard against DOS attacks.

Previous version bump: https://github.com/broadinstitute/push-to-cloud-service/pull/78